### PR TITLE
Build individual platforms

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
 	"files.exclude": {
 		".vs": true,
 		".vscode": true,
-		"build/pipeline": true,
+		"dist": true,
 		"node_modules": true
 	},
 	"javascript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets": false,

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ transform-tokens
 You'll get details of the arguments and their usage. Here's a full usage example:
 
 ```console
-transform-tokens --in mytokens.json --out build
+transform-tokens --in tokens.json --out build
 ```
 
 That will transform the tokens in one single JSON file and output them to a subfolder named `build`.
@@ -85,7 +85,7 @@ But let's get clear on the naming system that we have for different types of tok
 * Alias sets are just groups of alias tokens that can be reused for convenience and consistency. For example, `Set.AccentActionControl.Fill.Color` is a set that defines `.Rest`, `.Hover`, `.Pressed`, and `.Disabled` colors for that same part of the same type of control. Assigning something else to be an alias of that set is just a simpler way of assigning individual Rest, Hover, Press, and Disabled properties to those individual alias tokens—it's exactly equivalent.
 * Finally, controls in your UI platform of choice get their default styling values from control mappings, also known as control tokens. For example, an accent-colored button's base (background) element's fill color when hovered should be set to `AccentButton.Base.Fill.Color.Hover`.
 
-After transforming once, it can sometimes be helpful to refer to [`build/reference/fluentuitokens.html`](build/reference/fluentuitokens.html)—it's effectively a more human-readable version of `fluentui.json` that gets built by the pipeline.
+After transforming once, it can sometimes be helpful to refer to [`build/reference/fluentuitokens.html`](build/reference/fluentuitokens.html)—it's effectively a more human-readable version of your token JSON that gets built by the pipeline.
 
 ## Token organization
 
@@ -196,7 +196,7 @@ Unlike regular alias tokens, these computations can't be preserved in the output
 
 ## Value types
 
-Values in `fluentui.json` are stored in a universal format very similar to CSS web standards, and then converted to the proper format and syntax for each platform that the pipeline exports to.
+Values in token JSON are stored in a universal format very similar to CSS web standards, and then converted to the proper format and syntax for each platform that the pipeline exports to.
 
 The pipeline infers the data type from the token's full name, *not* its value. So, **it's important to follow the naming scheme of existing tokens in the pipeline**. You can see the code that handles this in [`fluentui-shared.ts`](src/pipeline/fluentui-shared.ts).
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,12 +1,15 @@
 import args from "args"
-import { buildEverything } from "../pipeline"
+import { buildOutputs } from "../pipeline"
 
 (() =>
 {
+	// Parse and validate the command-line arguments using the 'args' package.
 	args
-		.option("in", "One more more token JSON files to use as input", [])
+		.option("in", "A JSON file to use as input", [])
 		.option("out", "A path to output built files to", "build")
+		.option("platform", "A platform to build outputs for", [])
 		.example("transform-tokens --in mytokens.json --out build", "Transform mytokens.json and put the output in a folder called \"build\".")
+		.example("transform-tokens --in mytokens.json --out build -p winui -p css", "Just output the files for the winui and css platforms.")
 
 	const flags = args.parse(process.argv, { name: "transform-tokens" })
 
@@ -17,5 +20,17 @@ import { buildEverything } from "../pipeline"
 		return
 	}
 
-	buildEverything(flags.in, flags.out)
+	if (flags.platform[0] === true)
+	{
+		console.error("Specify a platform name to build outputs for, or leave off the --platform argument.\n")
+		args.showHelp()
+		return
+	}
+	else if (flags.platform.length === 0)
+	{
+		delete flags.platform
+	}
+
+	// Now, build what they asked for.
+	buildOutputs(flags.in, flags.out, flags.platform)
 })()

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -7,7 +7,7 @@ import { buildOutputs } from "../pipeline"
 	args
 		.option("in", "A JSON file to use as input", [])
 		.option("out", "A path to output built files to", "build")
-		.option("platform", "A platform to build outputs for", [])
+		.option("platform", "A platform to build outputs for (debug, json, reference, css, ios, winui)", [])
 		.example("transform-tokens --in mytokens.json --out build", "Transform mytokens.json and put the output in a folder called \"build\".")
 		.example("transform-tokens --in mytokens.json --out build -p winui -p css", "Just output the files for the winui and css platforms.")
 

--- a/src/pipeline/fluentui-platform-overrides.ts
+++ b/src/pipeline/fluentui-platform-overrides.ts
@@ -1,5 +1,5 @@
 import * as Utils from "./utils"
-import { Token, TokenSet, TokenPlatformOverrides, SupportedPlatform, TokenSetChildren } from "./types"
+import { Token, TokenSet, TokenPlatformOverrides, SupportedPlatform, SupportedPlatforms, TokenSetChildren } from "./types"
 
 /// Applies all of the overrides in an entire Style Dictionary properties object, and then returns the same object
 /// instance, modified.
@@ -10,8 +10,6 @@ export const resolvePlatformOverrides = (properties: TokenSet, currentPlatform: 
 	// Then, we just return the same object that was passed in, but modified.
 	return properties
 }
-
-const supportedTokenPlatformOverrides = { "winui": true }
 
 const resolvePlatformOverride = (prop: TokenSet | Token, currentPlatform: SupportedPlatform): void =>
 {
@@ -29,7 +27,7 @@ const resolvePlatformOverride = (prop: TokenSet | Token, currentPlatform: Suppor
 	// Now, make sure there aren't any unsupported platforms in the list.
 	for (const overrideKey in overrides)
 	{
-		if (!supportedTokenPlatformOverrides[overrideKey])
+		if (!SupportedPlatforms[overrideKey])
 		{
 			Utils.reportError(`A platform override for unsupported platform ${overrideKey} was ignored.`)
 			return

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -12,7 +12,7 @@ import "./fluentui-json"
 import "./fluentui-ios"
 import "./fluentui-winui"
 
-export const buildEverything = (input: string[] | string, outputPath: string): void =>
+export const buildOutputs = (input: string[] | string, outputPath: string, platforms: string[] | undefined): void =>
 {
 	let tokens = {}
 	if (typeof input === "string") input = [input]
@@ -21,61 +21,69 @@ export const buildEverything = (input: string[] | string, outputPath: string): v
 	tokens = resolveAliases(tokens)
 	tokens = resolveComputedTokens(tokens)
 
+	const sdPlatformData: any = {}
+
+	if (!platforms || platforms.includes("debug")) sdPlatformData.debug =
+		{
+			transformGroup: "js",
+			buildPath: `${outputPath}/debug/`,
+			files: [{ destination: "fluentuitokens-debug.json", format: "json" }],
+		}
+
+	if (!platforms || platforms.includes("json")) sdPlatformData.json =
+		{
+			transformGroup: "fluentui/json/grouped",
+			buildPath: `${outputPath}/json/`,
+			files: [{ destination: "fluentuitokens-grouped.json", format: "fluentui/json/grouped" }],
+		}
+
+	if (!platforms || platforms.includes("reference")) sdPlatformData.reference =
+		{
+			transformGroup: "fluentui/html",
+			buildPath: `${outputPath}/reference/`,
+			files: [{ destination: "fluentuitokens.html", format: "fluentui/html/reference" }],
+		}
+
+	if (!platforms || platforms.includes("ios")) sdPlatformData.ios =
+		{
+			transformGroup: "fluentui/swift",
+			buildPath: `${outputPath}/ios/`,
+			files: [
+				{ destination: "FluentUITokens.swift", format: "ios-swift/class.swift", className: "FluentUITokens" },
+				{ destination: "FluentUIColorTokens.swift", format: "ios-swift/class.swift", className: "FluentUIColorTokens", filter: "isColor" },
+				{ destination: "FluentUISizeTokens.swift", format: "ios-swift/class.swift", className: "FluentUISizeTokens", filter: "isSize" },
+				{ destination: "FluentUIFontTokens.swift", format: "ios-swift/class.swift", className: "FluentUIFontTokens", filter: "isFont" },
+			],
+		}
+
+	if (!platforms || platforms.includes("css")) sdPlatformData.css =
+		{
+			transformGroup: "fluentui/css",
+			buildPath: `${outputPath}/web/`,
+			files: [{ destination: "fluentuitokens.css", format: "css/variables" }],
+		}
+
+	if (!platforms || platforms.includes("cssflat")) sdPlatformData.cssflat =
+		{
+			transformGroup: "fluentui/cssflat",
+			buildPath: `${outputPath}/web/`,
+			files: [{ destination: "fluentuitokens-flat.css", format: "css/variables" }],
+		}
+
+	if (!platforms || platforms.includes("winui")) sdPlatformData.winui =
+		{
+			transformGroup: "fluentui/winui",
+			buildPath: `${outputPath}/winui/`,
+			files: [
+				{ destination: "FluentUITokens.xaml", format: "fluentui/xaml/res" },
+				{ destination: "FluentUITokensThemed.xaml", format: "fluentui/xaml/res/themed" },
+			],
+		}
+
 	const styleDictionary = require("style-dictionary").extend(
 		{
 			properties: tokens,
-
-			platforms: {
-				debug: {
-					transformGroup: "js",
-					buildPath: `${outputPath}/debug/`,
-					files: [{ destination: "fluentuitokens-debug.json", format: "json" }],
-				},
-
-				json: {
-					transformGroup: "fluentui/json/grouped",
-					buildPath: `${outputPath}/json/`,
-					files: [{ destination: "fluentuitokens-grouped.json", format: "fluentui/json/grouped" }],
-				},
-
-				reference: {
-					transformGroup: "fluentui/html",
-					buildPath: `${outputPath}/reference/`,
-					files: [{ destination: "fluentuitokens.html", format: "fluentui/html/reference" }],
-				},
-
-				ios: {
-					transformGroup: "fluentui/swift",
-					buildPath: `${outputPath}/ios/`,
-					files: [
-						{ destination: "FluentUITokens.swift", format: "ios-swift/class.swift", className: "FluentUITokens" },
-						{ destination: "FluentUIColorTokens.swift", format: "ios-swift/class.swift", className: "FluentUIColorTokens", filter: "isColor" },
-						{ destination: "FluentUISizeTokens.swift", format: "ios-swift/class.swift", className: "FluentUISizeTokens", filter: "isSize" },
-						{ destination: "FluentUIFontTokens.swift", format: "ios-swift/class.swift", className: "FluentUIFontTokens", filter: "isFont" },
-					],
-				},
-
-				css: {
-					transformGroup: "fluentui/css",
-					buildPath: `${outputPath}/web/`,
-					files: [{ destination: "fluentuitokens.css", format: "css/variables" }],
-				},
-
-				cssflat: {
-					transformGroup: "fluentui/cssflat",
-					buildPath: `${outputPath}/web/`,
-					files: [{ destination: "fluentuitokens-flat.css", format: "css/variables" }],
-				},
-
-				winui: {
-					transformGroup: "fluentui/winui",
-					buildPath: `${outputPath}/winui/`,
-					files: [
-						{ destination: "FluentUITokens.xaml", format: "fluentui/xaml/res" },
-						{ destination: "FluentUITokensThemed.xaml", format: "fluentui/xaml/res/themed" },
-					],
-				},
-			},
+			platforms: sdPlatformData,
 		}
 	)
 

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -1,6 +1,7 @@
 import _ from "lodash"
 import jsonfile from "jsonfile"
 
+import { SupportedPlatform, SupportedPlatforms } from "./types"
 import { resolveAliases } from "./fluentui-aliases"
 import { buildColorRamps } from "./fluentui-color-ramp"
 import { resolveComputedTokens } from "./fluentui-computed"
@@ -12,8 +13,17 @@ import "./fluentui-json"
 import "./fluentui-ios"
 import "./fluentui-winui"
 
-export const buildOutputs = (input: string[] | string, outputPath: string, platforms: string[] | undefined): void =>
+export const buildOutputs = (input: string[] | string, outputPath: string, platforms: SupportedPlatform[] | undefined): void =>
 {
+	if (platforms)
+	{
+		for (const platform of platforms)
+		{
+			if (!SupportedPlatforms[platform])
+				throw new Error(`Unsupported platform: ${platform}`)
+		}
+	}
+
 	let tokens = {}
 	if (typeof input === "string") input = [input]
 	input.forEach((inputFile) => _.merge(tokens, jsonfile.readFileSync(inputFile)))
@@ -21,71 +31,96 @@ export const buildOutputs = (input: string[] | string, outputPath: string, platf
 	tokens = resolveAliases(tokens)
 	tokens = resolveComputedTokens(tokens)
 
-	const sdPlatformData: any = {}
-
-	if (!platforms || platforms.includes("debug")) sdPlatformData.debug =
+	if (!platforms || platforms.includes("debug")) buildOnePlatform(tokens, /* platformOverride: */ null,
 		{
-			transformGroup: "js",
-			buildPath: `${outputPath}/debug/`,
-			files: [{ destination: "fluentuitokens-debug.json", format: "json" }],
-		}
-
-	if (!platforms || platforms.includes("json")) sdPlatformData.json =
-		{
-			transformGroup: "fluentui/json/grouped",
-			buildPath: `${outputPath}/json/`,
-			files: [{ destination: "fluentuitokens-grouped.json", format: "fluentui/json/grouped" }],
-		}
-
-	if (!platforms || platforms.includes("reference")) sdPlatformData.reference =
-		{
-			transformGroup: "fluentui/html",
-			buildPath: `${outputPath}/reference/`,
-			files: [{ destination: "fluentuitokens.html", format: "fluentui/html/reference" }],
-		}
-
-	if (!platforms || platforms.includes("ios")) sdPlatformData.ios =
-		{
-			transformGroup: "fluentui/swift",
-			buildPath: `${outputPath}/ios/`,
-			files: [
-				{ destination: "FluentUITokens.swift", format: "ios-swift/class.swift", className: "FluentUITokens" },
-				{ destination: "FluentUIColorTokens.swift", format: "ios-swift/class.swift", className: "FluentUIColorTokens", filter: "isColor" },
-				{ destination: "FluentUISizeTokens.swift", format: "ios-swift/class.swift", className: "FluentUISizeTokens", filter: "isSize" },
-				{ destination: "FluentUIFontTokens.swift", format: "ios-swift/class.swift", className: "FluentUIFontTokens", filter: "isFont" },
-			],
-		}
-
-	if (!platforms || platforms.includes("css")) sdPlatformData.css =
-		{
-			transformGroup: "fluentui/css",
-			buildPath: `${outputPath}/web/`,
-			files: [{ destination: "fluentuitokens.css", format: "css/variables" }],
-		}
-
-	if (!platforms || platforms.includes("cssflat")) sdPlatformData.cssflat =
-		{
-			transformGroup: "fluentui/cssflat",
-			buildPath: `${outputPath}/web/`,
-			files: [{ destination: "fluentuitokens-flat.css", format: "css/variables" }],
-		}
-
-	if (!platforms || platforms.includes("winui")) sdPlatformData.winui =
-		{
-			transformGroup: "fluentui/winui",
-			buildPath: `${outputPath}/winui/`,
-			files: [
-				{ destination: "FluentUITokens.xaml", format: "fluentui/xaml/res" },
-				{ destination: "FluentUITokensThemed.xaml", format: "fluentui/xaml/res/themed" },
-			],
-		}
-
-	const styleDictionary = require("style-dictionary").extend(
-		{
-			properties: tokens,
-			platforms: sdPlatformData,
+			debug:
+			{
+				transformGroup: "js",
+				buildPath: `${outputPath}/debug/`,
+				files: [{ destination: "fluentuitokens-debug.json", format: "json" }],
+			}
 		}
 	)
 
-	styleDictionary.buildAllPlatforms()
+	if (!platforms || platforms.includes("json")) buildOnePlatform(tokens, /* platformOverride: */ null,
+		{
+			json:
+			{
+				transformGroup: "fluentui/json/grouped",
+				buildPath: `${outputPath}/json/`,
+				files: [{ destination: "fluentuitokens-grouped.json", format: "fluentui/json/grouped" }],
+			}
+		}
+	)
+
+	if (!platforms || platforms.includes("reference")) buildOnePlatform(tokens, /* platformOverride: */ null,
+		{
+			reference:
+			{
+				transformGroup: "fluentui/html",
+				buildPath: `${outputPath}/reference/`,
+				files: [{ destination: "fluentuitokens.html", format: "fluentui/html/reference" }],
+			}
+		}
+	)
+
+	if (!platforms || platforms.includes("ios")) buildOnePlatform(tokens, "ios",
+		{
+			ios:
+			{
+				transformGroup: "fluentui/swift",
+				buildPath: `${outputPath}/ios/`,
+				files: [
+					{ destination: "FluentUITokens.swift", format: "ios-swift/class.swift", className: "FluentUITokens" },
+					{ destination: "FluentUIColorTokens.swift", format: "ios-swift/class.swift", className: "FluentUIColorTokens", filter: "isColor" },
+					{ destination: "FluentUISizeTokens.swift", format: "ios-swift/class.swift", className: "FluentUISizeTokens", filter: "isSize" },
+					{ destination: "FluentUIFontTokens.swift", format: "ios-swift/class.swift", className: "FluentUIFontTokens", filter: "isFont" },
+				],
+			}
+		}
+	)
+
+	if (!platforms || platforms.includes("css"))
+	{
+		buildOnePlatform(tokens, "css",
+			{
+				css:
+				{
+					transformGroup: "fluentui/css",
+					buildPath: `${outputPath}/web/`,
+					files: [{ destination: "fluentuitokens.css", format: "css/variables" }],
+				},
+				cssflat:
+				{
+					transformGroup: "fluentui/cssflat",
+					buildPath: `${outputPath}/web/`,
+					files: [{ destination: "fluentuitokens-flat.css", format: "css/variables" }],
+				}
+			}
+		)
+	}
+
+	if (!platforms || platforms.includes("winui")) buildOnePlatform(tokens, "winui",
+		{
+			winui:
+			{
+				transformGroup: "fluentui/winui",
+				buildPath: `${outputPath}/winui/`,
+				files: [
+					{ destination: "FluentUITokens.xaml", format: "fluentui/xaml/res" },
+					{ destination: "FluentUITokensThemed.xaml", format: "fluentui/xaml/res/themed" },
+				],
+			}
+		}
+	)
+}
+
+const buildOnePlatform = (tokens: any, platformOverride: SupportedPlatform | null, platformConfig: any): void =>
+{
+	require("style-dictionary").extend(
+		{
+			properties: platformOverride ? resolvePlatformOverrides(_.cloneDeep(tokens), platformOverride) : tokens,
+			platforms: platformConfig,
+		}
+	).buildAllPlatforms()
 }

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -119,7 +119,9 @@ const buildOnePlatform = (tokens: any, platformOverride: SupportedPlatform | nul
 {
 	require("style-dictionary").extend(
 		{
-			properties: platformOverride ? resolvePlatformOverrides(_.cloneDeep(tokens), platformOverride) : tokens,
+			// NYI: The platform overrides feature isn't finished yet, so don't enable it.
+			// properties: platformOverride ? resolvePlatformOverrides(_.cloneDeep(tokens), platformOverride) : _.cloneDeep(tokens),
+			properties: _.cloneDeep(tokens),
 			platforms: platformConfig,
 		}
 	).buildAllPlatforms()

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -53,12 +53,23 @@ export interface TokenColorComputation
 	opacity: number
 }
 
-export interface TokenPlatformOverrides
-{
-	winui?: TokenSetChildren
-}
+export type TokenPlatformOverrides = Partial<SupportedPlatformList<TokenSetChildren>>
 
-export type SupportedPlatform = keyof TokenPlatformOverrides
+export const SupportedPlatforms =
+{
+	debug: true,
+	json: true,
+	reference: true,
+	css: true,
+	cssflat: true,
+	ios: true,
+	winui: true,
+}
+export type SupportedPlatform = keyof typeof SupportedPlatforms
+export type SupportedPlatformList<ValueType> =
+{
+	[platform in SupportedPlatform]: ValueType
+}
 
 // ------------------------------------------------------------
 


### PR DESCRIPTION
This PR adds a `--platform <name>` flag to the CLI allowing you to build one or more platforms instead of everything at once. It also changes it so that platform outputs are built independently, which will be a requirement to complete issue #6.