### PR TITLE
Add new entries for NeutralForeground1

### DIFF
--- a/src/demo/fluentui-dark.json
+++ b/src/demo/fluentui-dark.json
@@ -10,6 +10,15 @@
           "Color": {
             "Rest": {
               "aliasOf": "Global.Color.White"
+            },
+            "Hover": {
+              "aliasOf": "Global.Color.White"
+            },
+            "Pressed": {
+              "aliasOf": "Global.Color.White"
+            },
+            "Selected": {
+              "aliasOf": "Global.Color.White"
             }
           }
         }

--- a/src/demo/fluentui-highContrast.json
+++ b/src/demo/fluentui-highContrast.json
@@ -9,6 +9,15 @@
           "Color": {
             "Rest": {
               "aliasOf": "Global.Color.hcCanvasText"
+            },
+            "Hover": {
+              "aliasOf": "Global.Color.hcHighlightText"
+            },
+            "Pressed": {
+              "aliasOf": "Global.Color.hcHighlightText"
+            },
+            "Selected": {
+              "aliasOf": "Global.Color.hcHighlightText"
             }
           }
         }

--- a/src/demo/fluentui-light.json
+++ b/src/demo/fluentui-light.json
@@ -9,6 +9,15 @@
 					"Color": {
 						"Rest": {
 							"aliasOf": "Global.Color.Grey.14"
+						},
+						"Hover": {
+							"aliasOf": "Global.Color.Grey.14"
+						},
+						"Pressed": {
+							"aliasOf": "Global.Color.Grey.14"
+						},
+						"Selected": {
+							"aliasOf": "Global.Color.Grey.14"
 						}
 					}
 				}

--- a/src/demo/fluentui-teamsDark.json
+++ b/src/demo/fluentui-teamsDark.json
@@ -10,6 +10,15 @@
           "Color": {
             "Rest": {
               "aliasOf": "Global.Color.White"
+            },
+            "Hover": {
+              "aliasOf": "Global.Color.White"
+            },
+            "Pressed": {
+              "aliasOf": "Global.Color.White"
+            },
+            "Selected": {
+              "aliasOf": "Global.Color.White"
             }
           }
         }


### PR DESCRIPTION
Needed to add interactivity colors for NeutralForeground1 so that the colors show correctly in HC. These have been added to the Figma. Porting this change for web, although I'm not sure if this is the full change that's needed. @miroslavstastny FYI