### PR TITLE
Add global alpha tokens

### DIFF
--- a/src/demo/fluentui-global.json
+++ b/src/demo/fluentui-global.json
@@ -55,6 +55,18 @@
 					"value": "grey"
 				}
 			},
+			"WhiteAlpha": {
+				"generate": {
+					"type": "alpha5to90",
+					"value": "white"
+				}
+			},
+			"BlackAlpha": {
+				"generate": {
+					"type": "alpha5to90",
+					"value": "black"
+				}
+			},
 			"White": {
 				"value": "#ffffff"
 			},

--- a/src/pipeline/fluentui-generate.ts
+++ b/src/pipeline/fluentui-generate.ts
@@ -47,6 +47,9 @@ const resolveGenerated = (prop: Token | TokenSet): void =>
 			return createLightness0to100by2Ramp(prop, value)
 		case "fluentsharedcolors":
 			return createSharedColorRamp(prop, value)
+		case "alpha5to90":
+			return createAlpha5to90Ramp(prop, value)
+
 		default:
 			throw new Error(`Unknown token set generation type in TokenGenerationTypes: ${JSON.stringify(type)}`)
 	}
@@ -110,4 +113,16 @@ const darken = (color: Color.ColorFormats.HSVA, factor: number): ValueToken =>
 const clamp = (value: number): number =>
 {
 	return value < 0 ? 0 : value > 1 ? 1 : value
+}
+
+const createAlpha5to90Ramp = (prop: TokenSet, value: string): void =>
+{
+	const alphas = [5, 10, 20, 30, 40, 50, 60, 70, 80, 90]
+	const rgba = new Color(value)
+
+	for (const alpha of alphas)
+	{
+		rgba.setAlpha(alpha / 100)
+		prop[alpha] = { value: rgba.toRgbString() }
+	}
 }

--- a/src/pipeline/fluentui-react.ts
+++ b/src/pipeline/fluentui-react.ts
@@ -92,7 +92,9 @@ StyleDictionary.registerTransformGroup({
 })
 
 const globalColorTypes = {
-	"grey": "Record<Greys, string>"
+	"grey": "Record<Greys, string>",
+	"whiteAlpha": "Record<AlphaColors, string>",
+	"blackAlpha": "Record<AlphaColors, string>",
 }
 
 StyleDictionary.registerFormat({
@@ -110,7 +112,7 @@ StyleDictionary.registerFormat({
 
 		const sharedColorNames: string[] = []
 		return [
-			"import type { GlobalSharedColors, ColorVariants, Greys } from '../types';",
+			"import type { GlobalSharedColors, ColorVariants, Greys, AlphaColors } from '../types';",
 			"",
 			...Object.keys(colors).map(colorName =>
 			{

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -38,6 +38,7 @@ export const TokenGenerationTypes =
 {
 	lightness0to100by2: true,
 	fluentsharedcolors: true,
+	alpha5to90: true,
 }
 export type TokenGenerationType = keyof typeof TokenGenerationTypes
 


### PR DESCRIPTION
Adds global alpha color tokens:
![image](https://user-images.githubusercontent.com/9615899/140974163-1acd58f1-c875-4630-92b1-68ffa0de55e4.png)

Example pipeline output (React):
```ts
export const whiteAlpha: Record<AlphaColors, string> = {
  "5": "rgba(255, 255, 255, 0.05)",
  "10": "rgba(255, 255, 255, 0.1)",
  "20": "rgba(255, 255, 255, 0.2)",
  "30": "rgba(255, 255, 255, 0.3)",
  "40": "rgba(255, 255, 255, 0.4)",
  "50": "rgba(255, 255, 255, 0.5)",
  "60": "rgba(255, 255, 255, 0.6)",
  "70": "rgba(255, 255, 255, 0.7)",
  "80": "rgba(255, 255, 255, 0.8)",
  "90": "rgba(255, 255, 255, 0.9)"
}

export const blackAlpha: Record<AlphaColors, string> = {
  "5": "rgba(0, 0, 0, 0.05)",
  "10": "rgba(0, 0, 0, 0.1)",
  "20": "rgba(0, 0, 0, 0.2)",
  "30": "rgba(0, 0, 0, 0.3)",
  "40": "rgba(0, 0, 0, 0.4)",
  "50": "rgba(0, 0, 0, 0.5)",
  "60": "rgba(0, 0, 0, 0.6)",
  "70": "rgba(0, 0, 0, 0.7)",
  "80": "rgba(0, 0, 0, 0.8)",
  "90": "rgba(0, 0, 0, 0.9)"
}
```