### PR TITLE
Add NeutralForeground1Static alias token

### DIFF
--- a/src/demo/fluentui-dark.json
+++ b/src/demo/fluentui-dark.json
@@ -154,6 +154,15 @@
           }
         }
       },
+      "NeutralForeground1Static": {
+        "Fill": {
+          "Color": {
+            "Rest": {
+              "aliasOf": "Global.Color.Grey.14"
+            }
+          }
+        }
+      },
       "NeutralForegroundInverted": {
         "Fill": {
           "Color": {
@@ -425,7 +434,7 @@
         "Fill": {
           "Color": {
             "Rest": {
-              "aliasOf": "Global.Color.Grey.20"
+              "aliasOf": "Global.Color.Grey.34"
             }
           }
         }
@@ -434,7 +443,7 @@
         "Fill": {
           "Color": {
             "Rest": {
-              "aliasOf": "Global.Color.Grey.34"
+              "aliasOf": "Global.Color.Grey.20"
             }
           }
         }

--- a/src/demo/fluentui-highContrast.json
+++ b/src/demo/fluentui-highContrast.json
@@ -154,6 +154,15 @@
           }
         }
       },
+      "NeutralForeground1Static": {
+        "Fill": {
+          "Color": {
+            "Rest": {
+              "aliasOf": "Global.Color.hcCanvas"
+            }
+          }
+        }
+      },
       "NeutralForegroundInverted": {
         "Fill": {
           "Color": {
@@ -425,7 +434,7 @@
         "Fill": {
           "Color": {
             "Rest": {
-              "aliasOf": "Global.Color.Grey.8"
+              "aliasOf": "Global.Color.hcCanvasText"
             }
           }
         }
@@ -434,7 +443,7 @@
         "Fill": {
           "Color": {
             "Rest": {
-              "aliasOf": "Global.Color.Grey.52"
+              "aliasOf": "Global.Color.hcCanvasText"
             }
           }
         }

--- a/src/demo/fluentui-light.json
+++ b/src/demo/fluentui-light.json
@@ -154,6 +154,15 @@
 					}
 				}
 			},
+			"NeutralForeground1Static": {
+				"Fill": {
+					"Color": {
+						"Rest": {
+							"aliasOf": "Global.Color.Grey.14"
+						}
+					}
+				}
+			},
 			"NeutralForegroundInverted": {
 				"Fill": {
 					"Color": {
@@ -335,7 +344,7 @@
 				"Fill": {
 					"Color": {
 						"Rest": {
-							"aliasOf": "Global.Color.Grey.20"
+							"aliasOf": "Global.Color.Grey.38"
 						}
 					}
 				}

--- a/src/demo/fluentui-teamsDark.json
+++ b/src/demo/fluentui-teamsDark.json
@@ -155,6 +155,15 @@
           }
         }
       },
+      "NeutralForeground1Static": {
+        "Fill": {
+          "Color": {
+            "Rest": {
+              "aliasOf": "Global.Color.Grey.14"
+            }
+          }
+        }
+      },
       "NeutralForegroundInverted": {
         "Fill": {
           "Color": {
@@ -426,7 +435,7 @@
         "Fill": {
           "Color": {
             "Rest": {
-              "aliasOf": "Global.Color.Grey.20"
+              "aliasOf": "Global.Color.Grey.34"
             }
           }
         }
@@ -435,7 +444,7 @@
         "Fill": {
           "Color": {
             "Rest": {
-              "aliasOf": "Global.Color.Grey.34"
+              "aliasOf": "Global.Color.Grey.20"
             }
           }
         }


### PR DESCRIPTION
1. add `colorNeutralForeground1Static` token
2. update `colorNeutralBackgroundInverted` token values
3. update `neutralStencil1` and `neutralStencil2` token values

## Old Behavior (columns - light, dark, teamsDark, highContrast)
![image](https://user-images.githubusercontent.com/9615899/150758337-131d3206-9cf8-4f52-b4a6-53fa7befebfc.png)
![image](https://user-images.githubusercontent.com/9615899/150758377-beb66a8d-e5f6-4c06-a2ca-c5ba9be32c71.png)

## Spec (columns - light, dark, highContrast, teamsDark)
![image](https://user-images.githubusercontent.com/9615899/150757526-de501a51-70ee-426a-b81f-c48ad964ea2f.png)
![image](https://user-images.githubusercontent.com/9615899/150757581-84c3598f-5755-40df-9256-0c1f465405a9.png)
![image](https://user-images.githubusercontent.com/9615899/150757612-c25f3d18-0b38-49c2-b75e-50f3c2a60b74.png)

## New Behavior (columns - light, dark, teamsDark, highContrast)
![image](https://user-images.githubusercontent.com/9615899/150757798-eaeb8367-3661-476f-92a1-73034380351d.png)
![image](https://user-images.githubusercontent.com/9615899/150757832-d2bd580c-24d3-4ef8-9b73-a6bd74307506.png)
![image](https://user-images.githubusercontent.com/9615899/150757875-31cbadfe-1b10-46b3-9d3b-2a1e27ce823c.png)

_Note: There is a difference between spec (#e5e5e5) and impl (#e6e6e6) for Grey.90, which is known._