### PR TITLE
Remove grey0 and grey100 by replacing lightness0to100by2 -> lightness2to98by2

### DIFF
--- a/docs/json.md
+++ b/docs/json.md
@@ -227,7 +227,7 @@ You can also specify an entire color ramp from a single base color value. Instea
 		"Grey": {
 			"2": { "value": "#050505" },
 			"4": { "value": "#0a0a0a" },
-			"98": { "value": "#fafafa" },
+			"98": { "value": "#fafafa" }
 		}
 	}
 }

--- a/docs/json.md
+++ b/docs/json.md
@@ -225,10 +225,9 @@ You can also specify an entire color ramp from a single base color value. Instea
 {
 	"Color": {
 		"Grey": {
-			"0": { "value": "#000000" },
 			"2": { "value": "#050505" },
 			"4": { "value": "#0a0a0a" },
-			"100": { "value": "#ffffff" },
+			"98": { "value": "#fafafa" },
 		}
 	}
 }
@@ -240,7 +239,7 @@ You can also specify an entire color ramp from a single base color value. Instea
 {
 	"Color": {
 		"Grey": {
-			"generate": { "type": "lightness0to100by2", "value": "#808080" }
+			"generate": { "type": "lightness2to98by2", "value": "#808080" }
 		}
 	}
 }
@@ -250,7 +249,7 @@ These color ramp algorithms are supported:
 
 | `type` | Description |
 | --- | --- |
-| `lightness0to100by2` | Produces a color ramp with values `0`, `2`, `4`, ... `100`, where each color differs only by HSL lightness value. `0` will be black, `100` will be white, and the values in-between will be different shades of the base color. |
+| `lightness2to98by2` | Produces a color ramp with values `2`, `4`, ... `98`, where each color differs only by HSL lightness value. `2` will be a shade above black, `98` will be a shade below white, and the values in-between will be different shades of the base color. |
 | `fluentsharedcolors` | Produces a color ramp with `Primary` as the base color, five darker shades as `Shade10` through `Shade50`, and six lighter tints as `Tint10` through `Tint60`. |
 
 **Important:** `value` must be a single color, not a gradient or alias of another token.

--- a/docs/token.schema.json
+++ b/docs/token.schema.json
@@ -222,7 +222,7 @@
 			"description": "The color token generation algorithm to use for this set. See the documentation for details on what tokens each algorithm generates.",
 			"type": "string",
 			"enum": [
-				"lightness0to100by2",
+				"lightness2to98by2",
 				"alpha5to90",
 				"fluentsharedcolors"
 			]

--- a/src/demo/fluentui.json
+++ b/src/demo/fluentui.json
@@ -24,7 +24,7 @@
 					"60": { "value": "#eff6fc" }
 				}
 			},
-			"Grey": { "generate": { "type": "lightness0to100by2", "value": "grey" } },
+			"Grey": { "generate": { "type": "lightness2to98by2", "value": "grey" } },
 			"HC": {
 				"Canvas": { "value": "Canvas" },
 				"CanvasText": { "value": "CanvasText" },
@@ -392,7 +392,7 @@
 		"NeutralBackground1": {
 			"Fill": {
 				"Color": {
-					"Rest": { "aliasOf": "Global.Color.Grey.100" },
+					"Rest": { "aliasOf": "Global.Color.White" },
 					"Hover": { "aliasOf": "Global.Color.Grey.96" },
 					"Pressed": { "aliasOf": "Global.Color.Grey.88" },
 					"Disabled": { "aliasOf": "Global.Color.Grey.94" }

--- a/src/pipeline/fluentui-generate.ts
+++ b/src/pipeline/fluentui-generate.ts
@@ -21,7 +21,7 @@ const resolveGenerated = (prop: Token | TokenSet): void =>
 	delete (prop as any).generate
 	if (typeof generationProperties !== "object")
 	{
-		Utils.setErrorValue(prop, "Invalid token set generation syntax", `Invalid token set generation syntax: ${JSON.stringify(generationProperties)}. The generate property should be an object like this: "generate": { "type": "lightness0to100by2", "value": "#0000ff" }.`)
+		Utils.setErrorValue(prop, "Invalid token set generation syntax", `Invalid token set generation syntax: ${JSON.stringify(generationProperties)}. The generate property should be an object like this: "generate": { "type": "lightness2to98by2", "value": "#0000ff" }.`)
 		return
 	}
 
@@ -43,8 +43,8 @@ const resolveGenerated = (prop: Token | TokenSet): void =>
 	delete (generationProperties as any).value
 	switch (type)
 	{
-		case "lightness0to100by2":
-			return createLightness0to100by2Ramp(prop, value)
+		case "lightness2to98by2":
+			return createLightness2to98by2Ramp(prop, value)
 		case "fluentsharedcolors":
 			return createSharedColorRamp(prop, value)
 		case "alpha5to90":
@@ -55,11 +55,11 @@ const resolveGenerated = (prop: Token | TokenSet): void =>
 	}
 }
 
-const createLightness0to100by2Ramp = (prop: TokenSet, value: string): void =>
+const createLightness2to98by2Ramp = (prop: TokenSet, value: string): void =>
 {
 	const hsl = new Color(value).toHsl()
 
-	for (let i = 0; i <= 100; i += 2)
+	for (let i = 2; i <= 98; i += 2)
 		prop[i.toString()] = { value: Color.fromRatio({ ...hsl, l: i / 100 }).toHexString() }
 }
 

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -36,7 +36,7 @@ export interface TokenGenerationProperties
 
 export const TokenGenerationTypes =
 {
-	lightness0to100by2: true,
+	lightness2to98by2: true,
 	fluentsharedcolors: true,
 	alpha5to90: true,
 }


### PR DESCRIPTION
Grey0 and grey100 are not specified in the updated designs for global color tokens. They are redundant with 'Black' and 'White'. Remove them by replacing `lightness0to100by2` with `lightness2to98by2`.

Also tried to update any references I saw to lightness0to100by2 so that the documentation still made sense.

Testing: 
- Followed instructions from https://microsoft.github.io/fluentui-token-pipeline/build.html
- Ran `npm run build` and `npm run transform` before this change and checked that build/react-native/tokens-global.json includes grey0/grey100, ran it after this change and confirmed that the file no longer contains grey0/grey100