### PR TITLE
W3C DTCG format input

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,7 +43,7 @@ You can use this CLI as a build step in another repo with this in your `package.
 
 ```json
 "devDependencies": {
-	"@fluentui/token-pipeline": "0.16.0"
+	"@fluentui/token-pipeline": "0.17.0"
 },
 "scripts": {
 	"build": "transform-tokens --in tokens.json --out build"

--- a/docs/json.md
+++ b/docs/json.md
@@ -8,6 +8,8 @@ title: Token JSON format reference
 
 This reference assumes that you're familiar with the general concept of design tokens.
 
+This reference also only describes the original proprietary design token format. The tool now also supports some input files in the [W3C Design Token Community Group format](https://design-tokens.github.io/community-group/format), but that format is not described here.
+
 After transforming once, it can sometimes be helpful to refer to [`build/reference/index.html`](../build/reference/index.html)—it's effectively a more human-readable version of your token JSON that gets built by the pipeline.
 
 ## Token organization
@@ -341,7 +343,7 @@ Note that stroke alignment doesn't actually affect the sizing of the element, an
 
 ## Versioning and validation
 
-Token JSON files should start with the following:
+Token JSON files must start with the following:
 
 ```json
 {
@@ -354,6 +356,7 @@ Token JSON files should start with the following:
 
 * The `$schema` property tells your text editor where to find the schema for token JSON, which will help you validate your tokens before running them through the pipeline.
 * The `Meta.FluentUITokensVersion` property indicates that your token JSON was created for use with this version of the pipeline and could be used in the future for compatibility.
+	* If this property is not present, the token file will be assumed to be in the DTCG format instead of the format described here.
 
 ### Validation errors in Visual Studio Code
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@fluentui/token-pipeline",
-	"version": "0.16.0",
+	"version": "0.17.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@fluentui/token-pipeline",
-			"version": "0.16.0",
+			"version": "0.17.0",
 			"license": "MIT",
 			"dependencies": {
 				"args": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
 		"build": "tsc",
 		"inc": "tsc --incremental --tsBuildInfoFile .tsbuildinfo",
 		"watch": "tsc --watch",
-		"transform": "node dist/cli --in src/demo/fluentui.json --out build",
-		"w3c": "node dist/cli --in src/demo/w3c/global.tokens.json --in src/demo/w3c/light.tokens.json --out build"
+		"transform": "node dist/cli --in src/demo/fluentui.json --out build"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluentui/token-pipeline",
-	"version": "0.16.0",
+	"version": "0.17.0",
 	"description": "The Fluent UI design token pipeline",
 	"repository": {
 		"type": "git",
@@ -53,6 +53,7 @@
 		"build": "tsc",
 		"inc": "tsc --incremental --tsBuildInfoFile .tsbuildinfo",
 		"watch": "tsc --watch",
-		"transform": "node dist/cli --in src/demo/fluentui.json --out build"
+		"transform": "node dist/cli --in src/demo/fluentui.json --out build",
+		"w3c": "node dist/cli --in src/demo/w3c/global.tokens.json --in src/demo/w3c/light.tokens.json --out build"
 	}
 }

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -5,7 +5,7 @@ import { buildOutputs } from "../pipeline"
 {
 	// Parse and validate the command-line arguments using the 'args' package.
 	args
-		.option("in", "A JSON file to use as input", [])
+		.option("in", "A JSON file (proprietary or DTCG format) to use as input", [])
 		.option("out", "A path to output built files to", "build")
 		.option("theme", "A string to denote theme")
 		.option("platform", "A platform to build outputs for (debug, json, reference, w3c, css, react, reactnative, ios, winui, figmatokens, dcs)", [])

--- a/src/demo/w3c/dark.tokens.json
+++ b/src/demo/w3c/dark.tokens.json
@@ -1,0 +1,994 @@
+{
+	"Neutral": {
+		"NeutralForeground1": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"NeutralForeground2": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.84}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"BrandHover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.100}"
+					},
+					"BrandPressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.90}"
+					},
+					"BrandSelected": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.100}"
+					}
+				}
+			}
+		},
+		"NeutralForeground3": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.68}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.84}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.84}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.84}"
+					},
+					"BrandHover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.100}"
+					},
+					"BrandPressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.90}"
+					},
+					"BrandSelected": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.100}"
+					}
+				}
+			}
+		},
+		"NeutralForeground4": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.60}"
+					}
+				}
+			}
+		},
+		"NeutralForegroundDisabled": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.36}"
+					}
+				}
+			}
+		},
+		"NeutralForegroundInvertedDisabled": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.WhiteAlpha.40}"
+					}
+				}
+			}
+		},
+		"BrandForegroundLink": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.100}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.110}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.90}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.100}"
+					}
+				}
+			}
+		},
+		"NeutralForeground2Link": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.84}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"CompoundBrandForeground1": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.100}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.110}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.90}"
+					}
+				}
+			}
+		},
+		"BrandForeground1": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.100}"
+					}
+				}
+			}
+		},
+		"BrandForeground2": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.110}"
+					}
+				}
+			}
+		},
+		"NeutralForeground1Static": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					}
+				}
+			}
+		},
+		"NeutralForegroundStaticInverted": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"NeutralForegroundInverted": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					}
+				}
+			}
+		},
+		"NeutralForegroundInverted2": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					}
+				}
+			}
+		},
+		"NeutralForegroundOnBrand": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"NeutralForegroundInvertedLink": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"BrandForegroundInverted": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.70}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.60}"
+					}
+				}
+			}
+		},
+		"BrandForegroundOnLight": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.70}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.50}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.60}"
+					}
+				}
+			}
+		},
+		"NeutralBackground1": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.16}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.24}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.12}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.22}"
+					}
+				}
+			}
+		},
+		"NeutralBackground2": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.12}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.20}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.8}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.18}"
+					}
+				}
+			}
+		},
+		"NeutralBackground3": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.8}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.16}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.4}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					}
+				}
+			}
+		},
+		"NeutralBackground4": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.4}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.12}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Black}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.10}"
+					}
+				}
+			}
+		},
+		"NeutralBackground5": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Black}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.8}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.2}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.6}"
+					}
+				}
+			}
+		},
+		"NeutralBackground6": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.20}"
+					}
+				}
+			}
+		},
+		"NeutralBackgroundInverted": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"NeutralBackgroundStatic": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.24}"
+					}
+				}
+			}
+		},
+		"SubtleBackground": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000000"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.22}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.18}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.20}"
+					},
+					"LightAlphaHover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey14Alpha.80}"
+					},
+					"LightAlphaPressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey14Alpha.50}"
+					},
+					"LightAlphaSelected": {
+						"$type": "color",
+						"$value": "#00000000"
+					}
+				}
+			}
+		},
+		"SubtleBackgroundInverted": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000000"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.BlackAlpha.10}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.BlackAlpha.30}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.BlackAlpha.20}"
+					}
+				}
+			}
+		},
+		"TransparentBackground": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000000"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "#00000000"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "#00000000"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "#00000000"
+					}
+				}
+			}
+		},
+		"NeutralBackgroundDisabled": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.8}"
+					}
+				}
+			}
+		},
+		"NeutralBackgroundInvertedDisabled": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.WhiteAlpha.10}"
+					}
+				}
+			}
+		},
+		"NeutralStencil1": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.34}"
+					}
+				}
+			}
+		},
+		"NeutralStencil2": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.20}"
+					}
+				}
+			}
+		},
+		"NeutralStencil1Alpha": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.WhiteAlpha.10}"
+					}
+				}
+			}
+		},
+		"NeutralStencil2Alpha": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.WhiteAlpha.5}"
+					}
+				}
+			}
+		},
+		"BackgroundOverlay": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.BlackAlpha.50}"
+					}
+				}
+			}
+		},
+		"ScrollbarOverlay": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.WhiteAlpha.60}"
+					}
+				}
+			}
+		},
+		"BrandBackground": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.70}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.40}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.60}"
+					}
+				}
+			}
+		},
+		"CompoundBrandBackground": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.100}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.110}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.90}"
+					}
+				}
+			}
+		},
+		"BrandBackgroundStatic": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					}
+				}
+			}
+		},
+		"BrandBackground2": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.40}"
+					}
+				}
+			}
+		},
+		"BrandBackgroundInverted": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.160}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.140}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.150}"
+					}
+				}
+			}
+		},
+		"NeutralStrokeAccessible": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.68}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.74}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.70}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.100}"
+					}
+				}
+			}
+		},
+		"NeutralStroke1": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.40}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.46}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.42}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.44}"
+					}
+				}
+			}
+		},
+		"NeutralStroke2": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.32}"
+					}
+				}
+			}
+		},
+		"NeutralStroke3": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.24}"
+					}
+				}
+			}
+		},
+		"NeutralStrokeOnBrand": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.16}"
+					}
+				}
+			}
+		},
+		"NeutralStrokeOnBrand2": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"BrandStroke1": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.100}"
+					}
+				}
+			}
+		},
+		"BrandStroke2": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.50}"
+					}
+				}
+			}
+		},
+		"CompoundBrandStroke": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.100}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.110}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.90}"
+					}
+				}
+			}
+		},
+		"NeutralStrokeDisabled": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.26}"
+					}
+				}
+			}
+		},
+		"NeutralStrokeInvertedDisabled": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.WhiteAlpha.40}"
+					}
+				}
+			}
+		},
+		"TransparentStroke": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000000"
+					}
+				}
+			}
+		},
+		"TransparentStrokeInteractive": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000000"
+					}
+				}
+			}
+		},
+		"TransparentStrokeDisabled": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000000"
+					}
+				}
+			}
+		},
+		"StrokeFocus1": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Black}"
+					}
+				}
+			}
+		},
+		"StrokeFocus2": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"NeutralShadowAmbient": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#0000003d"
+					}
+				}
+			}
+		},
+		"NeutralShadowKey": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000047"
+					}
+				}
+			}
+		},
+		"NeutralShadowAmbientLighter": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#0000001f"
+					}
+				}
+			}
+		},
+		"NeutralShadowKeyLighter": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000024"
+					}
+				}
+			}
+		},
+		"NeutralShadowAmbientDarker": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000066"
+					}
+				}
+			}
+		},
+		"NeutralShadowKeyDarker": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#0000007a"
+					}
+				}
+			}
+		},
+		"BrandShadowAmbient": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#0000004d"
+					}
+				}
+			}
+		},
+		"BrandShadowKey": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000040"
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/demo/w3c/global.tokens.json
+++ b/src/demo/w3c/global.tokens.json
@@ -1,0 +1,2918 @@
+{
+	"Global": {
+		"Color": {
+			"Brand": {
+				"10": {
+					"$type": "color",
+					"$value": "#001526"
+				},
+				"20": {
+					"$type": "color",
+					"$value": "#002848"
+				},
+				"30": {
+					"$type": "color",
+					"$value": "#043862"
+				},
+				"40": {
+					"$type": "color",
+					"$value": "#004578"
+				},
+				"50": {
+					"$type": "color",
+					"$value": "#004c87"
+				},
+				"60": {
+					"$type": "color",
+					"$value": "#005a9e"
+				},
+				"70": {
+					"$type": "color",
+					"$value": "#106ebe"
+				},
+				"80": {
+					"$type": "color",
+					"$value": "#0078d4"
+				},
+				"90": {
+					"$type": "color",
+					"$value": "#1890f1"
+				},
+				"100": {
+					"$type": "color",
+					"$value": "#2899f5"
+				},
+				"110": {
+					"$type": "color",
+					"$value": "#3aa0f3"
+				},
+				"120": {
+					"$type": "color",
+					"$value": "#6cb8f6"
+				},
+				"130": {
+					"$type": "color",
+					"$value": "#82c7ff"
+				},
+				"140": {
+					"$type": "color",
+					"$value": "#c7e0f4"
+				},
+				"150": {
+					"$type": "color",
+					"$value": "#deecf9"
+				},
+				"160": {
+					"$type": "color",
+					"$value": "#eff6fc"
+				}
+			},
+			"Grey": {
+				"0": {
+					"$type": "color",
+					"$value": "#000000"
+				},
+				"2": {
+					"$type": "color",
+					"$value": "#050505"
+				},
+				"4": {
+					"$type": "color",
+					"$value": "#0a0a0a"
+				},
+				"6": {
+					"$type": "color",
+					"$value": "#0f0f0f"
+				},
+				"8": {
+					"$type": "color",
+					"$value": "#141414"
+				},
+				"10": {
+					"$type": "color",
+					"$value": "#1a1a1a"
+				},
+				"12": {
+					"$type": "color",
+					"$value": "#1f1f1f"
+				},
+				"14": {
+					"$type": "color",
+					"$value": "#242424"
+				},
+				"16": {
+					"$type": "color",
+					"$value": "#292929"
+				},
+				"18": {
+					"$type": "color",
+					"$value": "#2e2e2e"
+				},
+				"20": {
+					"$type": "color",
+					"$value": "#333333"
+				},
+				"22": {
+					"$type": "color",
+					"$value": "#383838"
+				},
+				"24": {
+					"$type": "color",
+					"$value": "#3d3d3d"
+				},
+				"26": {
+					"$type": "color",
+					"$value": "#424242"
+				},
+				"28": {
+					"$type": "color",
+					"$value": "#474747"
+				},
+				"30": {
+					"$type": "color",
+					"$value": "#4d4d4d"
+				},
+				"32": {
+					"$type": "color",
+					"$value": "#525252"
+				},
+				"34": {
+					"$type": "color",
+					"$value": "#575757"
+				},
+				"36": {
+					"$type": "color",
+					"$value": "#5c5c5c"
+				},
+				"38": {
+					"$type": "color",
+					"$value": "#616161"
+				},
+				"40": {
+					"$type": "color",
+					"$value": "#666666"
+				},
+				"42": {
+					"$type": "color",
+					"$value": "#6b6b6b"
+				},
+				"44": {
+					"$type": "color",
+					"$value": "#707070"
+				},
+				"46": {
+					"$type": "color",
+					"$value": "#757575"
+				},
+				"48": {
+					"$type": "color",
+					"$value": "#7a7a7a"
+				},
+				"50": {
+					"$type": "color",
+					"$value": "#808080"
+				},
+				"52": {
+					"$type": "color",
+					"$value": "#858585"
+				},
+				"54": {
+					"$type": "color",
+					"$value": "#8a8a8a"
+				},
+				"56": {
+					"$type": "color",
+					"$value": "#8f8f8f"
+				},
+				"58": {
+					"$type": "color",
+					"$value": "#949494"
+				},
+				"60": {
+					"$type": "color",
+					"$value": "#999999"
+				},
+				"62": {
+					"$type": "color",
+					"$value": "#9e9e9e"
+				},
+				"64": {
+					"$type": "color",
+					"$value": "#a3a3a3"
+				},
+				"66": {
+					"$type": "color",
+					"$value": "#a8a8a8"
+				},
+				"68": {
+					"$type": "color",
+					"$value": "#adadad"
+				},
+				"70": {
+					"$type": "color",
+					"$value": "#b3b3b3"
+				},
+				"72": {
+					"$type": "color",
+					"$value": "#b8b8b8"
+				},
+				"74": {
+					"$type": "color",
+					"$value": "#bdbdbd"
+				},
+				"76": {
+					"$type": "color",
+					"$value": "#c2c2c2"
+				},
+				"78": {
+					"$type": "color",
+					"$value": "#c7c7c7"
+				},
+				"80": {
+					"$type": "color",
+					"$value": "#cccccc"
+				},
+				"82": {
+					"$type": "color",
+					"$value": "#d1d1d1"
+				},
+				"84": {
+					"$type": "color",
+					"$value": "#d6d6d6"
+				},
+				"86": {
+					"$type": "color",
+					"$value": "#dbdbdb"
+				},
+				"88": {
+					"$type": "color",
+					"$value": "#e0e0e0"
+				},
+				"90": {
+					"$type": "color",
+					"$value": "#e6e6e6"
+				},
+				"92": {
+					"$type": "color",
+					"$value": "#ebebeb"
+				},
+				"94": {
+					"$type": "color",
+					"$value": "#f0f0f0"
+				},
+				"96": {
+					"$type": "color",
+					"$value": "#f5f5f5"
+				},
+				"98": {
+					"$type": "color",
+					"$value": "#fafafa"
+				},
+				"100": {
+					"$type": "color",
+					"$value": "#ffffff"
+				}
+			},
+			"WhiteAlpha": {
+				"5": {
+					"$type": "color",
+					"$value": "#ffffff0d"
+				},
+				"10": {
+					"$type": "color",
+					"$value": "#ffffff1a"
+				},
+				"20": {
+					"$type": "color",
+					"$value": "#ffffff33"
+				},
+				"30": {
+					"$type": "color",
+					"$value": "#ffffff4d"
+				},
+				"40": {
+					"$type": "color",
+					"$value": "#ffffff66"
+				},
+				"50": {
+					"$type": "color",
+					"$value": "#ffffff80"
+				},
+				"60": {
+					"$type": "color",
+					"$value": "#ffffff99"
+				},
+				"70": {
+					"$type": "color",
+					"$value": "#ffffffb3"
+				},
+				"80": {
+					"$type": "color",
+					"$value": "#ffffffcc"
+				},
+				"90": {
+					"$type": "color",
+					"$value": "#ffffffe6"
+				}
+			},
+			"BlackAlpha": {
+				"5": {
+					"$type": "color",
+					"$value": "#0000000d"
+				},
+				"10": {
+					"$type": "color",
+					"$value": "#0000001a"
+				},
+				"20": {
+					"$type": "color",
+					"$value": "#00000033"
+				},
+				"30": {
+					"$type": "color",
+					"$value": "#0000004d"
+				},
+				"40": {
+					"$type": "color",
+					"$value": "#00000066"
+				},
+				"50": {
+					"$type": "color",
+					"$value": "#00000080"
+				},
+				"60": {
+					"$type": "color",
+					"$value": "#00000099"
+				},
+				"70": {
+					"$type": "color",
+					"$value": "#000000b3"
+				},
+				"80": {
+					"$type": "color",
+					"$value": "#000000cc"
+				},
+				"90": {
+					"$type": "color",
+					"$value": "#000000e6"
+				}
+			},
+			"Grey14Alpha": {
+				"5": {
+					"$type": "color",
+					"$value": "#2424240d"
+				},
+				"10": {
+					"$type": "color",
+					"$value": "#2424241a"
+				},
+				"20": {
+					"$type": "color",
+					"$value": "#24242433"
+				},
+				"30": {
+					"$type": "color",
+					"$value": "#2424244d"
+				},
+				"40": {
+					"$type": "color",
+					"$value": "#24242466"
+				},
+				"50": {
+					"$type": "color",
+					"$value": "#24242480"
+				},
+				"60": {
+					"$type": "color",
+					"$value": "#24242499"
+				},
+				"70": {
+					"$type": "color",
+					"$value": "#242424b3"
+				},
+				"80": {
+					"$type": "color",
+					"$value": "#242424cc"
+				},
+				"90": {
+					"$type": "color",
+					"$value": "#242424e6"
+				}
+			},
+			"White": {
+				"$type": "color",
+				"$value": "#ffffff"
+			},
+			"Black": {
+				"$type": "color",
+				"$value": "#000000"
+			},
+			"hcHyperlink": {
+				"$type": "color",
+				"$value": "#75e9fc",
+				"$extensions": {
+					"com.microsoft.systemcolor": "LinkText"
+				}
+			},
+			"hcHighlight": {
+				"$type": "color",
+				"$value": "#8ee3f0",
+				"$extensions": {
+					"com.microsoft.systemcolor": "Highlight"
+				}
+			},
+			"hcDisabled": {
+				"$type": "color",
+				"$value": "#a6a6a6",
+				"$extensions": {
+					"com.microsoft.systemcolor": "GrayText"
+				}
+			},
+			"hcCanvas": {
+				"$type": "color",
+				"$value": "#202020",
+				"$extensions": {
+					"com.microsoft.systemcolor": "Canvas"
+				}
+			},
+			"hcCanvasText": {
+				"$type": "color",
+				"$value": "#ffffff",
+				"$extensions": {
+					"com.microsoft.systemcolor": "CanvasText"
+				}
+			},
+			"hcHighlightText": {
+				"$type": "color",
+				"$value": "#263b50",
+				"$extensions": {
+					"com.microsoft.systemcolor": "HighlightText"
+				}
+			},
+			"hcButtonText": {
+				"$type": "color",
+				"$value": "#ffffff",
+				"$extensions": {
+					"com.microsoft.systemcolor": "ButtonText"
+				}
+			},
+			"hcButtonFace": {
+				"$type": "color",
+				"$value": "#202020",
+				"$extensions": {
+					"com.microsoft.systemcolor": "ButtonFace"
+				}
+			},
+			"DarkRed": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#130204"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#230308"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#420610"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#590815"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#690a19"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#750b1c"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#861b2c"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#962f3f"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#ac4f5e"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#d69ca5"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#e9c7cd"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f9f0f2"
+				}
+			},
+			"Burgundy": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#1a0607"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#310b0d"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#5c1519"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#7d1d21"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#942228"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#a4262c"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#af393e"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#ba4d52"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#c86c70"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#e4afb2"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#f0d3d4"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fbf4f4"
+				}
+			},
+			"Cranberry": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#200205"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#3b0509"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#6e0811"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#960b18"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#b10e1c"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#c50f1f"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#cc2635"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#d33f4c"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#dc626d"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#eeacb2"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#f6d1d5"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fdf3f4"
+				}
+			},
+			"Red": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#210809"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#3f1011"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#751d1f"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#9f282b"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#bc2f32"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#d13438"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#d7494c"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#dc5e62"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#e37d80"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#f1bbbc"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#f8dadb"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fdf6f6"
+				}
+			},
+			"DarkOrange": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#230900"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#411200"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#7a2101"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#a62d01"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#c43501"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#da3b01"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#de501c"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#e36537"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#e9835e"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#f4bfab"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#f9dcd1"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fdf6f3"
+				}
+			},
+			"Bronze": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#1b0a01"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#321303"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#5e2405"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#7f3107"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#963a08"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#a74109"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#b2521e"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#bc6535"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#ca8057"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#e5bba4"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#f1d9cc"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fbf5f2"
+				}
+			},
+			"Pumpkin": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#200d03"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#3d1805"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#712d09"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#9a3d0c"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#b6480e"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#ca5010"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#d06228"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#d77440"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#df8e64"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#efc4ad"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#f7dfd2"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fdf7f4"
+				}
+			},
+			"Orange": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#271002"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#4a1e04"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#8a3707"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#bc4b09"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#de590b"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#f7630c"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#f87528"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#f98845"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#faa06b"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#fdcfb4"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#fee5d7"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fff9f5"
+				}
+			},
+			"Peach": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#291600"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#4d2a00"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#8f4e00"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#c26a00"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#e67e00"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#ff8c00"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#ff9a1f"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#ffa83d"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#ffba66"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#ffddb3"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#ffedd6"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fffaf5"
+				}
+			},
+			"Marigold": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#251a00"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#463100"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#835b00"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#b27c00"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#d39300"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#eaa300"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#edad1c"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#efb839"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#f2c661"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#f9e2ae"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#fcefd3"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fefbf4"
+				}
+			},
+			"Yellow": {
+				"Primary": {
+					"$type": "color",
+					"$value": "#fde300"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#e4cc00"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#c0ad00"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#817400"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#4c4400"
+				},
+				"Shade50": {
+					"$type": "color",
+					"$value": "#282400"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#fde61e"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#fdea3d"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#feee66"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#fef7b2"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#fffad6"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fffef5"
+				}
+			},
+			"Gold": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#1f1900"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#3a2f00"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#6c5700"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#937700"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#ae8c00"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#c19c00"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#c8a718"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#d0b232"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#dac157"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#ecdfa5"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#f5eece"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fdfbf2"
+				}
+			},
+			"Brass": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#181202"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#2e2103"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#553e06"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#745408"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#89640a"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#986f0b"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#a47d1e"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#b18c34"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#c1a256"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#e0cea2"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#efe4cb"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fbf8f2"
+				}
+			},
+			"Brown": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#170e07"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#2b1a0e"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#50301a"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#6c4123"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#804d29"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#8e562e"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#9c663f"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#a97652"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#bb8f6f"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#ddc3b0"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#edded3"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#faf7f4"
+				}
+			},
+			"DarkBrown": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#0c0704"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#170c08"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#2b1710"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#3a1f15"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#452519"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#4d291c"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#623a2b"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#784d3e"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#946b5c"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#caada3"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#e3d2cb"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f8f3f2"
+				}
+			},
+			"Lime": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#121b06"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#23330b"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#405f14"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#57811b"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#689920"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#73aa24"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#81b437"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#90be4c"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#a4cc6c"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#cfe5af"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#e5f1d3"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f8fcf4"
+				}
+			},
+			"Forest": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#0c1501"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#162702"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#294903"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#376304"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#427505"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#498205"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#599116"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#6ba02b"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#85b44c"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#bdd99b"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#dbebc7"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f6faf0"
+				}
+			},
+			"Seafoam": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#002111"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#003d20"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#00723b"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#009b51"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#00b85f"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#00cc6a"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#19d279"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#34d889"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#5ae0a0"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#a8f0cd"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#cff7e4"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f3fdf8"
+				}
+			},
+			"LightGreen": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#031a02"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#063004"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#0b5a08"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#0e7a0b"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#11910d"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#13a10e"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#27ac22"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#3db838"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#5ec75a"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#a7e3a5"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#cef0cd"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f2fbf2"
+				}
+			},
+			"Green": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#031403"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#052505"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#094509"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#0c5e0c"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#0e700e"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#107c10"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#218c21"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#359b35"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#54b054"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#9fd89f"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#c9eac9"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f1faf1"
+				}
+			},
+			"DarkGreen": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#021102"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#032003"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#063b06"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#085108"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#0a5f0a"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#0b6a0b"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#1a7c1a"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#2d8e2d"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#4da64d"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#9ad29a"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#c6e7c6"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f0f9f0"
+				}
+			},
+			"LightTeal": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#001d1f"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#00373a"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#00666d"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#008b94"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#00a5af"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#00b7c3"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#18bfca"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#32c8d1"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#58d3db"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#a6e9ed"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#cef3f5"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f2fcfd"
+				}
+			},
+			"Teal": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#001516"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#012728"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#02494c"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#026467"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#037679"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#038387"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#159195"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#2aa0a4"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#4cb4b7"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#9bd9db"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#c7ebec"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f0fafa"
+				}
+			},
+			"DarkTeal": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#001010"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#001f1f"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#003939"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#004e4e"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#005c5c"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#006666"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#0e7878"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#218b8b"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#41a3a3"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#92d1d1"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#c2e7e7"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#eff9f9"
+				}
+			},
+			"Cyan": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#00181e"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#002e38"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#005669"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#00748f"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#008aa9"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#0099bc"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#18a4c4"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#31afcc"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#56bfd7"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#a4deeb"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#cdedf4"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f2fafc"
+				}
+			},
+			"Steel": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#000f12"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#001b22"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#00333f"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#004555"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#005265"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#005b70"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#0f6c81"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#237d92"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#4496a9"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#94c8d4"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#c3e1e8"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#eff7f9"
+				}
+			},
+			"LightBlue": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#091823"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#112d42"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#20547c"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#2c72a8"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#3487c7"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#3a96dd"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#4fa1e1"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#65ade5"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#83bdeb"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#bfddf5"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#dcedfa"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f6fafe"
+				}
+			},
+			"Blue": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#001322"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#002440"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#004377"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#005ba1"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#006cbf"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#0078d4"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#1a86d9"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#3595de"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#5caae5"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#a9d3f2"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#d0e7f8"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f3f9fd"
+				}
+			},
+			"RoyalBlue": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#000c16"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#00172a"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#002c4e"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#003b6a"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#00467e"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#004e8c"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#125e9a"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#286fa8"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#4a89ba"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#9abfdc"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#c7dced"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f0f6fa"
+				}
+			},
+			"DarkBlue": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#000910"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#00111f"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#002039"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#002b4e"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#00335c"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#003966"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#0e4a78"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#215c8b"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#4178a3"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#92b5d1"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#c2d6e7"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#eff4f9"
+				}
+			},
+			"Cornflower": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#0d1126"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#182047"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#2c3c85"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#3c51b4"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#4760d5"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#4f6bed"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#637cef"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#778df1"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#93a4f4"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#c8d1fa"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#e1e6fc"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f7f9fe"
+				}
+			},
+			"Navy": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#00061d"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#000c36"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#001665"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#001e89"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#0023a2"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#0027b4"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#173bbd"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#3050c6"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#546fd2"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#a3b2e8"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#ccd5f3"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f2f4fc"
+				}
+			},
+			"Lavender": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#120f25"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#221d46"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#3f3682"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#5649b0"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#6656d1"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#7160e8"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#8172eb"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#9184ee"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#a79cf1"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#d2ccf8"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#e7e4fb"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f9f8fe"
+				}
+			},
+			"Purple": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#0f0717"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#1c0e2b"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#341a51"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#46236e"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#532982"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#5c2e91"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#6b3f9e"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#7c52ab"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#9470bd"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#c6b1de"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#e0d3ed"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f7f4fb"
+				}
+			},
+			"DarkPurple": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#0a0411"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#130820"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#240f3c"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#311552"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#3a1861"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#401b6c"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#512b7e"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#633e8f"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#7e5ca7"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#b9a3d3"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#d8cce7"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f5f2f9"
+				}
+			},
+			"Orchid": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#16101d"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#281e37"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#4c3867"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#674c8c"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#795aa6"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#8764b8"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#9373c0"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#a083c9"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#b29ad4"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#d7caea"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#e9e2f4"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f9f8fc"
+				}
+			},
+			"Grape": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#160418"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#29072e"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#4c0d55"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#671174"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#7a1589"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#881798"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#952aa4"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#a33fb1"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#b55fc1"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#d9a7e0"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#eaceef"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#faf2fb"
+				}
+			},
+			"Berry": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#1f091d"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#3a1136"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#6d2064"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#932b88"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#af33a1"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#c239b3"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#c94cbc"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#d161c4"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#da7ed0"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#edbbe7"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#f5daf2"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fdf5fc"
+				}
+			},
+			"Lilac": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#1c0b1f"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#35153a"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#63276d"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#863593"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#9f3faf"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#b146c2"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#ba58c9"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#c36bd1"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#cf87da"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#e6bfed"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#f2dcf5"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fcf6fd"
+				}
+			},
+			"Pink": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#24091b"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#441232"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#80215d"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#ad2d7e"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#cd3595"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#e43ba6"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#e750b0"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#ea66ba"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#ef85c8"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#f7c0e3"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#fbddf0"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fef6fb"
+				}
+			},
+			"HotPink": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#240016"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#44002a"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#7f004e"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#ad006a"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#cc007e"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#e3008c"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#e61c99"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#ea38a6"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#ee5fb7"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#f7adda"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#fbd2eb"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fef4fa"
+				}
+			},
+			"Magenta": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#1f0013"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#390024"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#6b0043"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#91005a"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#ac006b"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#bf0077"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#c71885"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#ce3293"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#d957a8"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#eca5d1"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#f5cee6"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fcf2f9"
+				}
+			},
+			"Plum": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#13000c"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#240017"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#43002b"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#5a003b"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#6b0045"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#77004d"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#87105d"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#98246f"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#ad4589"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#d696c0"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#e9c4dc"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#faf0f6"
+				}
+			},
+			"Beige": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#141313"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#252323"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#444241"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#5d5958"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#6e6968"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#7a7574"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#8a8584"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#9a9594"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#afabaa"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#d7d4d4"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#eae8e8"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#faf9f9"
+				}
+			},
+			"Mink": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#0f0e0e"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#1c1b1a"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#343231"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#474443"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#54514f"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#5d5a58"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#706d6b"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#84817e"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#9e9b99"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#cecccb"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#e5e4e3"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f8f8f8"
+				}
+			},
+			"Silver": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#151818"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#282d2e"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#4a5356"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#657174"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#78868a"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#859599"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#92a1a5"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#a0aeb1"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#b3bfc2"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#d8dfe0"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#eaeeef"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#fafbfb"
+				}
+			},
+			"Platinum": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#111314"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#1f2426"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#3b4447"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#505c60"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#5f6d71"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#69797e"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#79898d"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#89989d"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#a0adb2"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#cdd6d8"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#e4e9ea"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f8f9fa"
+				}
+			},
+			"Anchor": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#090a0b"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#111315"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#202427"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#2b3135"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#333a3f"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#394146"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#4d565c"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#626c72"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#808a90"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#bcc3c7"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#dbdfe1"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f6f7f8"
+				}
+			},
+			"Charcoal": {
+				"Shade50": {
+					"$type": "color",
+					"$value": "#090909"
+				},
+				"Shade40": {
+					"$type": "color",
+					"$value": "#111111"
+				},
+				"Shade30": {
+					"$type": "color",
+					"$value": "#202020"
+				},
+				"Shade20": {
+					"$type": "color",
+					"$value": "#2b2b2b"
+				},
+				"Shade10": {
+					"$type": "color",
+					"$value": "#333333"
+				},
+				"Primary": {
+					"$type": "color",
+					"$value": "#393939"
+				},
+				"Tint10": {
+					"$type": "color",
+					"$value": "#515151"
+				},
+				"Tint20": {
+					"$type": "color",
+					"$value": "#686868"
+				},
+				"Tint30": {
+					"$type": "color",
+					"$value": "#888888"
+				},
+				"Tint40": {
+					"$type": "color",
+					"$value": "#c4c4c4"
+				},
+				"Tint50": {
+					"$type": "color",
+					"$value": "#dfdfdf"
+				},
+				"Tint60": {
+					"$type": "color",
+					"$value": "#f7f7f7"
+				}
+			}
+		}
+	}
+}

--- a/src/demo/w3c/light.tokens.json
+++ b/src/demo/w3c/light.tokens.json
@@ -1,0 +1,994 @@
+{
+	"Neutral": {
+		"NeutralForeground1": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					}
+				}
+			}
+		},
+		"NeutralForeground2": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.26}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					},
+					"BrandHover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					},
+					"BrandPressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.70}"
+					},
+					"BrandSelected": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					}
+				}
+			}
+		},
+		"NeutralForeground3": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.38}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.26}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.26}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.26}"
+					},
+					"BrandHover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					},
+					"BrandPressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.70}"
+					},
+					"BrandSelected": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					}
+				}
+			}
+		},
+		"NeutralForeground4": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.44}"
+					}
+				}
+			}
+		},
+		"NeutralForegroundDisabled": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.74}"
+					}
+				}
+			}
+		},
+		"NeutralForegroundInvertedDisabled": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.WhiteAlpha.40}"
+					}
+				}
+			}
+		},
+		"BrandForegroundLink": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.70}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.60}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.40}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.70}"
+					}
+				}
+			}
+		},
+		"NeutralForeground2Link": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.26}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					}
+				}
+			}
+		},
+		"CompoundBrandForeground1": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.70}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.60}"
+					}
+				}
+			}
+		},
+		"BrandForeground1": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					}
+				}
+			}
+		},
+		"BrandForeground2": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.70}"
+					}
+				}
+			}
+		},
+		"NeutralForeground1Static": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.14}"
+					}
+				}
+			}
+		},
+		"NeutralForegroundStaticInverted": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"NeutralForegroundInverted": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"NeutralForegroundInverted2": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"NeutralForegroundOnBrand": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"NeutralForegroundInvertedLink": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"BrandForegroundInverted": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.100}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.110}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.100}"
+					}
+				}
+			}
+		},
+		"BrandForegroundOnLight": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.70}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.50}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.60}"
+					}
+				}
+			}
+		},
+		"NeutralBackground1": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.96}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.88}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.92}"
+					}
+				}
+			}
+		},
+		"NeutralBackground2": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.98}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.94}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.86}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.90}"
+					}
+				}
+			}
+		},
+		"NeutralBackground3": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.96}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.92}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.84}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.88}"
+					}
+				}
+			}
+		},
+		"NeutralBackground4": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.94}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.98}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.96}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"NeutralBackground5": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.92}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.96}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.94}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.98}"
+					}
+				}
+			}
+		},
+		"NeutralBackground6": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.90}"
+					}
+				}
+			}
+		},
+		"NeutralBackgroundInverted": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.16}"
+					}
+				}
+			}
+		},
+		"NeutralBackgroundStatic": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.20}"
+					}
+				}
+			}
+		},
+		"SubtleBackground": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000000"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.96}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.88}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.92}"
+					},
+					"LightAlphaHover": {
+						"$type": "color",
+						"$value": "{Global.Color.WhiteAlpha.70}"
+					},
+					"LightAlphaPressed": {
+						"$type": "color",
+						"$value": "{Global.Color.WhiteAlpha.50}"
+					},
+					"LightAlphaSelected": {
+						"$type": "color",
+						"$value": "#00000000"
+					}
+				}
+			}
+		},
+		"SubtleBackgroundInverted": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000000"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.BlackAlpha.10}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.BlackAlpha.30}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.BlackAlpha.20}"
+					}
+				}
+			}
+		},
+		"TransparentBackground": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000000"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "#00000000"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "#00000000"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "#00000000"
+					}
+				}
+			}
+		},
+		"NeutralBackgroundDisabled": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.94}"
+					}
+				}
+			}
+		},
+		"NeutralBackgroundInvertedDisabled": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.WhiteAlpha.10}"
+					}
+				}
+			}
+		},
+		"NeutralStencil1": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.90}"
+					}
+				}
+			}
+		},
+		"NeutralStencil2": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.98}"
+					}
+				}
+			}
+		},
+		"NeutralStencil1Alpha": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.BlackAlpha.10}"
+					}
+				}
+			}
+		},
+		"NeutralStencil2Alpha": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.BlackAlpha.5}"
+					}
+				}
+			}
+		},
+		"BackgroundOverlay": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.BlackAlpha.40}"
+					}
+				}
+			}
+		},
+		"ScrollbarOverlay": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.BlackAlpha.50}"
+					}
+				}
+			}
+		},
+		"BrandBackground": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.70}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.40}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.60}"
+					}
+				}
+			}
+		},
+		"CompoundBrandBackground": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.70}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.60}"
+					}
+				}
+			}
+		},
+		"BrandBackgroundStatic": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					}
+				}
+			}
+		},
+		"BrandBackground2": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.160}"
+					}
+				}
+			}
+		},
+		"BrandBackgroundInverted": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.160}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.140}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.150}"
+					}
+				}
+			}
+		},
+		"NeutralStrokeAccessible": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.38}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.34}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.30}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					}
+				}
+			}
+		},
+		"NeutralStroke1": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.82}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.78}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.70}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.74}"
+					}
+				}
+			}
+		},
+		"NeutralStroke2": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.88}"
+					}
+				}
+			}
+		},
+		"NeutralStroke3": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.94}"
+					}
+				}
+			}
+		},
+		"NeutralStrokeOnBrand": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"NeutralStrokeOnBrand2": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					},
+					"Selected": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"BrandStroke1": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					}
+				}
+			}
+		},
+		"BrandStroke2": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.140}"
+					}
+				}
+			}
+		},
+		"CompoundBrandStroke": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.80}"
+					},
+					"Hover": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.70}"
+					},
+					"Pressed": {
+						"$type": "color",
+						"$value": "{Global.Color.Brand.60}"
+					}
+				}
+			}
+		},
+		"NeutralStrokeDisabled": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Grey.88}"
+					}
+				}
+			}
+		},
+		"NeutralStrokeInvertedDisabled": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.WhiteAlpha.40}"
+					}
+				}
+			}
+		},
+		"TransparentStroke": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000000"
+					}
+				}
+			}
+		},
+		"TransparentStrokeInteractive": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000000"
+					}
+				}
+			}
+		},
+		"TransparentStrokeDisabled": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000000"
+					}
+				}
+			}
+		},
+		"StrokeFocus1": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.White}"
+					}
+				}
+			}
+		},
+		"StrokeFocus2": {
+			"Stroke": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "{Global.Color.Black}"
+					}
+				}
+			}
+		},
+		"NeutralShadowAmbient": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#0000001f"
+					}
+				}
+			}
+		},
+		"NeutralShadowKey": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000024"
+					}
+				}
+			}
+		},
+		"NeutralShadowAmbientLighter": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#0000000f"
+					}
+				}
+			}
+		},
+		"NeutralShadowKeyLighter": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000012"
+					}
+				}
+			}
+		},
+		"NeutralShadowAmbientDarker": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000033"
+					}
+				}
+			}
+		},
+		"NeutralShadowKeyDarker": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#0000003d"
+					}
+				}
+			}
+		},
+		"BrandShadowAmbient": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#0000004d"
+					}
+				}
+			}
+		},
+		"BrandShadowKey": {
+			"Fill": {
+				"Color": {
+					"Rest": {
+						"$type": "color",
+						"$value": "#00000040"
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/pipeline/fluentui-aliases.ts
+++ b/src/pipeline/fluentui-aliases.ts
@@ -47,6 +47,8 @@ const resolveAlias = (prop: Token, properties: TokenSet): AliasToken | null =>
 	if (target === null)
 	{
 		Utils.setErrorValue(prop, `token ${JSON.stringify(prop.aliasOf)} missing`, `Invalid aliasOf: ${JSON.stringify(prop.aliasOf)}. That token doesn't exist.`)
+		const propAsAny = prop as any
+		propAsAny.resolvedAliasPath = Utils.getTokenExportPath(prop, prop.aliasOf)
 		return null
 	}
 

--- a/src/pipeline/fluentui-css.ts
+++ b/src/pipeline/fluentui-css.ts
@@ -102,7 +102,7 @@ const specialColorFallbacks: Record<string, string> =
 	"canvas": "#202020",
 	"canvastext": "#ffffff",
 	"linktext": "#75e9fc",
-	"graytext": "#a6a6at",
+	"graytext": "#a6a6a6",
 	"highlight": "#8ee3f0",
 	"highlighttext": "#263b50",
 	"buttonface": "#202020",

--- a/src/pipeline/fluentui-w3c.ts
+++ b/src/pipeline/fluentui-w3c.ts
@@ -92,7 +92,7 @@ StyleDictionary.registerFormat({
 	formatter: (dictionary, config) =>
 	{
 		const tokens = getW3CJson(dictionary.allProperties)
-		return JSON.stringify(tokens, /* replacer: */ undefined, /* space: */ "\t")
+		return JSON.stringify(tokens, /* replacer: */ undefined, /* space: */ "\t") + "\n"
 	},
 })
 

--- a/src/pipeline/fluentui-w3c.ts
+++ b/src/pipeline/fluentui-w3c.ts
@@ -61,16 +61,22 @@ StyleDictionary.registerTransform({
 	matcher: prop => prop.attributes.category === "shadow",
 	transformer: prop =>
 	{
-		if (prop.value.length > 1)
-			Utils.reportError(`Only the first shadow defined for token ${prop.path.join(".")} could be exported because the W3C format only supports single shadows.`)
-		const shadow = prop.value[0]
-		return {
-			color: colorTokenToHexColorFallback(shadow.color),
-			offsetX: `${shadow.x}px`,
-			offsetY: `${shadow.y}px`,
-			blur: `${shadow.blur}px`,
-			spread: "0px",
-		}
+		// WARNING: as of February 2023 the DTCG format for shadows does not allow an array of shadows, but it's a near-sure thing and we can't use
+		// any of the Fluent shadows without it, so I'm just assuming it will be added.
+		// See: https://github.com/design-tokens/community-group/issues/100
+		return prop.value.map(shadow =>
+		{
+			// It isn't currently possible to have Style Dictionary export strings with {}, so use [] instead.
+			// REVIEW: Do we need to strip "Set." here?
+			const color = shadow.color.resolvedAliasPath ? `[${shadow.color.resolvedAliasPath.join(".")}]` : colorTokenToHexColorFallback(shadow.color.value)
+			return {
+				color: color,
+				offsetX: `${shadow.x}px`,
+				offsetY: `${shadow.y}px`,
+				blur: `${shadow.blur}px`,
+				spread: "0px",
+			}
+		})
 	},
 })
 
@@ -122,6 +128,7 @@ export const getValueOrReference = (prop: any): any =>
 {
 	if (prop.resolvedAliasPath)
 	{
+		// REVIEW: Do we need to strip "Set" here?
 		return `{${prop.resolvedAliasPath.join(".")}}`
 	}
 	else

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -1,8 +1,8 @@
 import _ from "lodash"
-import jsonfile from "jsonfile"
 
 import { SupportedPlatform, SupportedPlatforms, SupportedThemes } from "./types"
 import { mergeNumbers } from "./utils"
+import { loadTokensFile } from "./load"
 import { resolveAliases } from "./fluentui-aliases"
 import { resolveGeneratedSets } from "./fluentui-generate"
 import { resolveComputedTokens } from "./fluentui-computed"
@@ -49,7 +49,7 @@ export const buildOutputs = (input: string[] | string, outputPath: string, platf
 
 	const tokens = {}
 	if (typeof input === "string") input = [input]
-	input.forEach((inputFile) => _.merge(tokens, jsonfile.readFileSync(inputFile)))
+	input.forEach((inputFile) => _.merge(tokens, loadTokensFile(inputFile)))
 
 	if (!platforms || platforms.includes("debug")) buildOnePlatform(tokens, /* platformOverride: */ null,
 		{

--- a/src/pipeline/load.ts
+++ b/src/pipeline/load.ts
@@ -1,0 +1,137 @@
+import jsonfile from "jsonfile"
+import { Token, TokenJson, TokenSet } from "./types"
+
+export const loadTokensFile = (inputFile: string): TokenSet =>
+{
+	const tokens: TokenJson = jsonfile.readFileSync(inputFile)
+	if (typeof (tokens) !== "object")
+	{
+		throw new Error(`${inputFile} is not a valid token file.`)
+	}
+
+	if ("Meta" in tokens)
+	{
+		if (tokens.Meta.FluentUITokensVersion !== 0)
+		{
+			throw new Error(`${inputFile} is a token file but in unsupported version ${JSON.stringify(tokens.Meta.FluentUITokensVersion)}.`)
+		}
+		// This is a proprietary tokens file that this tool knows how to transform.
+		return tokens
+	}
+	else
+	{
+		// Our best guess is that this is a W3C-format tokens file, so convert it into our format first so the existing code works as-is.
+		return convertW3CTokens(tokens)
+	}
+}
+
+const convertW3CTokens = (tokens: any): TokenJson =>
+{
+	// Note that this function isn't intended to be able to fully round-trip tokens back and forth between the W3C format;
+	// it's just intended to be "good enough" to allow our existing code to continue working with W3C-format token files.
+	// This is a lossy process!
+
+	const converted: any = { Meta: { FluentUITokensVersion: 0 } }
+	for (const childName in tokens)
+	{
+		if (isReservedW3CName(childName)) continue
+		if (!tokens.hasOwnProperty(childName)) continue
+
+		if (childName === "Global")
+		{
+			convertAndCopyTokens(tokens.Global, converted.Global = {})
+		}
+		else
+		{
+			// Anything that's not in the Global namespace gets "Set." prepended to the name so that existing code that assumes
+			// that word will be there will continue working.
+			if (!("Set" in converted)) converted.Set = {}
+			convertAndCopyTokens(tokens[childName], converted.Set[childName] = {})
+		}
+	}
+	return converted as TokenJson
+}
+
+const convertAndCopyTokens = (from: any, to: TokenSet): void =>
+{
+	for (const childName in from)
+	{
+		if (isReservedW3CName(childName)) continue
+		if (!from.hasOwnProperty(childName)) continue
+		const w3cToken = from[childName]
+		if (isToken(w3cToken))
+		{
+			to[childName] = getConvertedToken(w3cToken)
+		}
+		else if (isTokenGroup(w3cToken))
+		{
+			if (childName in to) throw new Error(`Oops, there was already a set called "${childName}"... that shouldn't have happened!`)
+			convertAndCopyTokens(w3cToken, to[childName] = {})
+		}
+		else
+		{
+			throw new Error(`Unexpected ${typeof w3cToken} child "${childName}" found.`)
+		}
+	}
+}
+
+const getConvertedToken = (w3cToken: Record<string, any>): Token =>
+{
+	let value = w3cToken.$value
+	let attributes: any = { w3cType: w3cToken.$type }
+	const aliasTarget = getW3CAliasTargetName(value)
+	const converted: any = aliasTarget ? { aliasOf: aliasTarget } : {}
+
+	switch (w3cToken.$type)
+	{
+		case undefined:
+			throw new Error(`Token missing required $type: ${JSON.stringify(w3cToken)}`)
+		case "color":
+			if ("$extensions" in w3cToken && "com.microsoft.systemcolor" in w3cToken.$extensions)
+			{
+				value = w3cToken.$extensions["com.microsoft.systemcolor"]
+			}
+			attributes = { category: "color", figmaTokensType: "color", xamlType: "SolidColorBrush" }
+			break
+		case "dimension":
+			value = parseInt(value, 10)
+			attributes = { category: "size", figmaTokensType: "sizing", xamlType: "x:Double" }
+			break
+		case "fontFamily":
+			if (Array.isArray(value)) value = JSON.stringify(value).slice(1, -1)
+			attributes = { category: "font", figmaTokensType: "fontFamilies", xamlType: "FontFamily" }
+			break
+		case "fontSize":
+			value = parseInt(value, 10)
+			attributes = { category: "size", figmaTokensType: "fontSizes", xamlType: "x:Double" }
+			break
+		default:
+			throw new Error(`Token had an unsupported $type: ${w3cToken.$type}`)
+	}
+
+	if (!aliasTarget) converted.value = value
+	converted.attributes = attributes
+	return converted as unknown as Token
+}
+
+const isReservedW3CName = (key: string): boolean =>
+{
+	return key.charCodeAt(0) === 36 /* "$" */
+}
+
+const isToken = (obj: any): boolean =>
+{
+	return typeof obj === "object" && "$value" in obj
+}
+
+const isTokenGroup = (obj: any): boolean =>
+{
+	return typeof obj === "object" && !("$value" in obj)
+}
+
+const getW3CAliasTargetName = (value: any): string | null =>
+{
+	if (typeof value === "string" && value.charCodeAt(0) === 123 /* "{" */ && value.charCodeAt(value.length - 1) === 125 /* "}" */)
+		return value.slice(1, -1)
+	else return null
+}

--- a/src/pipeline/load.ts
+++ b/src/pipeline/load.ts
@@ -105,6 +105,10 @@ const getConvertedToken = (w3cToken: Record<string, any>): Token =>
 			value = parseInt(value, 10)
 			attributes = { category: "size", figmaTokensType: "fontSizes", xamlType: "x:Double" }
 			break
+		case "fontWeight":
+			value = parseInt(value, 10)
+			attributes = { category: "fontWeight", figmaTokensType: "fontWeight", xamlType: "x:Double" }
+			break
 		default:
 			throw new Error(`Token had an unsupported $type: ${w3cToken.$type}`)
 	}

--- a/src/pipeline/load.ts
+++ b/src/pipeline/load.ts
@@ -114,7 +114,8 @@ const getConvertedToken = (w3cToken: Record<string, any>): Token =>
 			value = value.map(shadow =>
 			{
 				// [] isn't actual valid aliasing syntax, but Style Dictionary doesn't let us export strings with {} so we support both.
-				const color = (shadow.color[0] === "{" || shadow.color[0] === "[") ? { aliasOf: shadow.color.slice(1, -1) } : { value: shadow.color }
+				const first = shadow.color.charCodeAt(0)
+				const color = (first === 123 /* "{" */ || first === 91 /* "[" */) ? { aliasOf: shadow.color.slice(1, -1) } : { value: shadow.color }
 				return {
 					color: color,
 					x: parseFloat(shadow.offsetX),


### PR DESCRIPTION
This PR adds support to the pipeline for *consuming* [W3C DTCG draft format](https://design-tokens.github.io/community-group/format/) token files. JSON files and the proprietary syntax and the DTCG format can be mixed and matched—the pipeline will convert DTCG tokens into the old syntax when loading so that existing code investments continue to function.

This is not a general-purpose DTCG format parser—think of it as a custom compatibility shim, not a full parser. I'm only supporting the specific token types and syntaxes that the Fluent platforms are using. I'm also assuming that the `shadow` token type will be extended to support an array of shadows, which seems virtually guaranteed but is not formally allowed by the spec.

Without changing input files to the DTCG format, this PR should introduce only minimal changes:

* A typo is fixed when using the `GrayText` high contrast / system color
* The `Meta` node is now required when importing proprietary JSON (all of our files already have it)