### PR TITLE
Remove everything related to "Set"

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,7 +43,7 @@ You can use this CLI as a build step in another repo with this in your `package.
 
 ```json
 "devDependencies": {
-	"@fluentui/token-pipeline": "0.19.0"
+	"@fluentui/token-pipeline": "0.20.0"
 },
 "scripts": {
 	"build": "transform-tokens --in tokens.json --out build"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@fluentui/token-pipeline",
-	"version": "0.19.0",
+	"version": "0.20.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@fluentui/token-pipeline",
-			"version": "0.19.0",
+			"version": "0.20.0",
 			"license": "MIT",
 			"dependencies": {
 				"args": "^5.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@fluentui/token-pipeline",
-	"version": "0.20.0",
+	"version": "0.20.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@fluentui/token-pipeline",
-			"version": "0.20.0",
+			"version": "0.20.1",
 			"license": "MIT",
 			"dependencies": {
 				"args": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluentui/token-pipeline",
-	"version": "0.20.0",
+	"version": "0.20.1",
 	"description": "The Fluent UI design token pipeline",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@fluentui/token-pipeline",
-	"version": "0.19.0",
+	"version": "0.20.0",
 	"description": "The Fluent UI design token pipeline",
 	"repository": {
 		"type": "git",

--- a/src/demo/fluentui-overrides.json
+++ b/src/demo/fluentui-overrides.json
@@ -6,7 +6,7 @@
 		"Base": {
 			"Fill": {
 				"Color": {
-					"aliasOf": "Set.MergeMe.Fill.Color",
+					"aliasOf": "MergeMe.Fill.Color",
 					"Red": { "value": "red" },
 					"WrongName": { "value": "blue", "fullName": "OverrideTests-Base-Fill-Color-Blue" },
 					"Silver": { "fullName": "OverrideTests-Base-Fill-Color-Grey" },
@@ -15,27 +15,25 @@
 			},
 			"Stroke": {
 				"Color": {
-					"aliasOf": "Set.PlatformOverrides.Stroke.Color"
+					"aliasOf": "PlatformOverrides.Stroke.Color"
 				}
 			}
 		}
 	},
-	"Set": {
-		"MergeMe": {
-			"Fill": {
-				"Color": {
-					"Green": { "value": "green" },
-					"Silver": { "value": "silver", "fullName": "Set-MergeMe-Fill-Color-SilverSpecialNameForSetOnly" },
-					"Magenta": { "value": "magenta" }
-				}
+	"MergeMe": {
+		"Fill": {
+			"Color": {
+				"Green": { "value": "green" },
+				"Silver": { "value": "silver", "fullName": "MergeMe-Fill-Color-SilverSpecialNameForSetOnly" },
+				"Magenta": { "value": "magenta" }
 			}
-		},
-		"PlatformOverrides": {
-			"Stroke": {
-				"Color": {
-					"YellowExceptPurpleInWinUI": { "value": "yellow", "platform": { "winui": { "value": "purple" } } },
-					"OrangeExceptBlackInWinUI": { "value": "orange", "platform": { "winui": { "value": "black", "fullName": "PlatformOverrides-Stroke-Color-BlackInWinUI" } } }
-				}
+		}
+	},
+	"PlatformOverrides": {
+		"Stroke": {
+			"Color": {
+				"YellowExceptPurpleInWinUI": { "value": "yellow", "platform": { "winui": { "value": "purple" } } },
+				"OrangeExceptBlackInWinUI": { "value": "orange", "platform": { "winui": { "value": "black", "fullName": "PlatformOverrides-Stroke-Color-BlackInWinUI" } } }
 			}
 		}
 	}

--- a/src/demo/fluentui-unused.json
+++ b/src/demo/fluentui-unused.json
@@ -27,5 +27,261 @@
 		"ComputedColors": {
 			"TranslucentAccent": { "computed": { "color": "Global.Color.AccentBase", "opacity": 0.05 } }
 		}
+	},
+	"Button": {
+		"Content": {
+			"Font": { "aliasOf": "Control.Font" },
+			"Fill": { "Color": { "aliasOf": "NeutralForeground1.Fill.Color", "Selected": { "aliasOf": "NeutralForeground1Selected.Fill.Color" } } }
+		},
+		"Icon": {
+			"Fill": { "Color": { "aliasOf": "NeutralForeground1.Fill.Color", "Selected": { "aliasOf": "NeutralForeground1Selected.Fill.Color" } } }
+		},
+		"Base": {
+			"Fill": { "Color": { "aliasOf": "NeutralBackground1.Fill.Color", "Selected": { "aliasOf": "NeutralBackground1Selected.Fill.Color" } } },
+			"Stroke": {
+				"Color": { "aliasOf": "NeutralStroke1.Stroke.Color", "Selected": { "aliasOf": "NeutralStroke1Selected.Stroke.Color" } },
+				"Width": { "aliasOf": "NeutralStroke1.Stroke.Width", "Selected": { "aliasOf": "NeutralStroke1Selected.Stroke.Width" } }
+			},
+			"Corner": { "aliasOf": "Control.Corner" },
+			"Layout": { "Padding": { "value": [ 7, 15, 7, 15 ] } }
+		}
+	},
+
+	"ButtonPrimary": {
+		"Content": {
+			"Font": { "aliasOf": "Control.Font" },
+			"Fill": { "Color": { "aliasOf": "NeutralForegroundInvertedAccessible.Fill.Color", "Selected": { "aliasOf": "NeutralForegroundInvertedAccessibleSelected.Fill.Color" } } }
+		},
+		"Icon": {
+			"Fill": { "Color": { "aliasOf": "NeutralForegroundInvertedAccessible.Fill.Color", "Selected": { "aliasOf": "NeutralForegroundInvertedAccessibleSelected.Fill.Color" } } }
+		},
+		"Base": {
+			"Fill": { "Color": { "aliasOf": "BrandBackground.Fill.Color", "Selected": { "aliasOf": "BrandBackgroundSelected.Fill.Color" } } },
+			"Stroke": {
+				"Color": { "aliasOf": "Borderless.Stroke.Color", "Selected": { "aliasOf": "Borderless.Stroke.Color" } },
+				"Width": { "aliasOf": "Borderless.Stroke.Width", "Selected": { "aliasOf": "Borderless.Stroke.Width" } }
+			},
+			"Corner": { "aliasOf": "Control.Corner" },
+			"Layout": { "Padding": { "value": [ 7, 15, 7, 15 ] } }
+		}
+	},
+
+	"ButtonOutline": {
+		"Content": {
+			"Font": { "aliasOf": "Control.Font" },
+			"Fill": { "Color": { "aliasOf": "NeutralForeground1.Fill.Color", "Selected": { "aliasOf": "NeutralForeground1Selected.Fill.Color" } } }
+		},
+		"Icon": {
+			"Fill": { "Color": { "aliasOf": "NeutralForeground1.Fill.Color", "Selected": { "aliasOf": "NeutralForeground1Selected.Fill.Color" } } }
+		},
+		"Base": {
+			"Fill": { "Color": { "aliasOf": "TransparentBackground.Fill.Color", "Selected": { "aliasOf": "TransparentBackgroundSelected.Fill.Color" } } },
+			"Stroke": {
+				"Color": { "aliasOf": "NeutralStroke1.Stroke.Color", "Selected": { "aliasOf": "NeutralStroke1.Stroke.Color" } },
+				"Width": { "aliasOf": "NeutralStroke1.Stroke.Width", "Selected": { "aliasOf": "NeutralStroke1.Stroke.Width" } }
+			},
+			"Corner": { "aliasOf": "Control.Corner" },
+			"Layout": { "Padding": { "value": [7, 15, 7, 15] } }
+		}
+	},
+
+	"ButtonGhost": {
+		"Content": {
+			"Font": { "aliasOf": "Body.Font" },
+			"Fill": { "Color": { "aliasOf": "NeutralForeground2Brand.Fill.Color", "Selected": { "aliasOf": "NeutralForeground2BrandSelected.Fill.Color" } } }
+		},
+		"Icon": {
+			"Fill": { "Color": { "aliasOf": "NeutralForeground2Brand.Fill.Color", "Selected": { "aliasOf": "NeutralForeground2BrandSelected.Fill.Color" } } }
+		},
+		"Base": {
+			"Fill": { "Color": { "aliasOf": "GhostBackground.Fill.Color", "Selected": { "aliasOf": "GhostBackgroundSelected.Fill.Color" } } },
+			"Stroke": {
+				"Color": { "aliasOf": "Borderless.Stroke.Color", "Selected": { "aliasOf": "Borderless.Stroke.Color" } },
+				"Width": { "aliasOf": "Borderless.Stroke.Width", "Selected": { "aliasOf": "Borderless.Stroke.Width" } }
+			},
+			"Corner": { "aliasOf": "Control.Corner" },
+			"Layout": { "Padding": { "value": [ 7, 15, 7, 15 ] } }
+		}
+	},
+
+	"CheckBox": {
+		"Text": {
+			"Font": { "aliasOf": "Body.Font" },
+			"Fill": {
+				"Color": {
+					"aliasOf": "NeutralForegroundInvertedAccessible.Fill.Color",
+					"platform": {
+						"winui": {
+							"Rest": { "fullName": "CheckBoxForegroundUnchecked" },
+							"Hover": { "fullName": "CheckBoxForegroundUncheckedPointerOver" },
+							"Press": { "fullName": "CheckBoxForegroundUncheckedPressed" },
+							"Disabled": { "fullName": "CheckBoxForegroundUncheckedDisabled" }
+						}
+					},
+					"Selected": {
+						"aliasOf": "NeutralForegroundInvertedAccessible.Fill.Color",
+						"platform": {
+							"winui": {
+								"Rest": { "fullName": "CheckBoxForegroundChecked" },
+								"Hover": { "fullName": "CheckBoxForegroundCheckedPointerOver" },
+								"Press": { "fullName": "CheckBoxForegroundCheckedPressed" },
+								"Disabled": { "fullName": "CheckBoxForegroundCheckedDisabled" }
+							}
+						}
+					},
+					"Indeterminate": {
+						"aliasOf": "NeutralForegroundInvertedAccessible.Fill.Color",
+						"platform": {
+							"winui": {
+								"Rest": { "fullName": "CheckBoxForegroundIndeterminate" },
+								"Hover": { "fullName": "CheckBoxForegroundIndeterminatePointerOver" },
+								"Press": { "fullName": "CheckBoxForegroundIndeterminatePressed" },
+								"Disabled": { "fullName": "CheckBoxForegroundIndeterminateDisabled" }
+							}
+						}
+					}
+				}
+			}
+		},
+		"Check": {
+			"Fill": {
+				"Color": {
+					"aliasOf": "NeutralForegroundInvertedAccessible.Fill.Color",
+					"platform": {
+						"winui": {
+							"Rest": { "fullName": "CheckBoxCheckGlyphForegroundUnchecked" },
+							"Hover": { "fullName": "CheckBoxCheckGlyphForegroundUncheckedPointerOver" },
+							"Press": { "fullName": "CheckBoxCheckGlyphForegroundUncheckedPressed" },
+							"Disabled": { "fullName": "CheckBoxCheckGlyphForegroundUncheckedDisabled" }
+						}
+					},
+					"Selected": {
+						"aliasOf": "NeutralForegroundInvertedAccessible.Fill.Color",
+						"platform": {
+							"winui": {
+								"Rest": { "fullName": "CheckBoxCheckGlyphForegroundChecked" },
+								"Hover": { "fullName": "CheckBoxCheckGlyphForegroundCheckedPointerOver" },
+								"Press": { "fullName": "CheckBoxCheckGlyphForegroundCheckedPressed" },
+								"Disabled": { "fullName": "CheckBoxCheckGlyphForegroundCheckedDisabled" }
+							}
+						}
+					},
+					"Indeterminate": {
+						"aliasOf": "NeutralForegroundInvertedAccessible.Fill.Color",
+						"platform": {
+							"winui": {
+								"Rest": { "fullName": "CheckBoxCheckGlyphForegroundIndeterminate" },
+								"Hover": { "fullName": "CheckBoxCheckGlyphForegroundIndeterminatePointerOver" },
+								"Press": { "fullName": "CheckBoxCheckGlyphForegroundIndeterminatePressed" },
+								"Disabled": { "fullName": "CheckBoxCheckGlyphForegroundIndeterminateDisabled" }
+							}
+						}
+					}
+				}
+			}
+		},
+		"Box": {
+			"Fill": {
+				"Color": {
+					"aliasOf": "TransparentBackground.Fill.Color",
+					"platform": {
+						"winui": {
+							"Rest": { "fullName": "CheckBoxCheckBackgroundFillUnchecked" },
+							"Hover": { "fullName": "CheckBoxCheckBackgroundFillUncheckedPointerOver" },
+							"Press": { "fullName": "CheckBoxCheckBackgroundFillUncheckedPressed" },
+							"Disabled": { "fullName": "CheckBoxCheckBackgroundFillUncheckedDisabled" }
+						}
+					},
+					"Selected": { "aliasOf": "BrandBackground.Fill.Color",
+						"platform": {
+							"winui": {
+								"Rest": { "fullName": "CheckBoxCheckBackgroundFillChecked" },
+								"Hover": { "fullName": "CheckBoxCheckBackgroundFillCheckedPointerOver" },
+								"Press": { "fullName": "CheckBoxCheckBackgroundFillCheckedPressed" },
+								"Disabled": { "fullName": "CheckBoxCheckBackgroundFillCheckedDisabled" }
+							}
+						} },
+					"Indeterminate": { "aliasOf": "BrandBackground.Fill.Color",
+						"platform": {
+							"winui": {
+								"Rest": { "fullName": "CheckBoxCheckBackgroundFillIndeterminate" },
+								"Hover": { "fullName": "CheckBoxCheckBackgroundFillIndeterminatePointerOver" },
+								"Press": { "fullName": "CheckBoxCheckBackgroundFillIndeterminatePressed" },
+								"Disabled": { "fullName": "CheckBoxCheckBackgroundFillIndeterminateDisabled" }
+							}
+						} }
+				}
+			},
+			"Stroke": {
+				"Color": {
+					"aliasOf": "NeutralStroke1.Stroke.Color",
+					"platform": {
+						"winui": {
+							"Rest": { "fullName": "CheckBoxCheckBackgroundStrokeUnchecked" },
+							"Hover": { "fullName": "CheckBoxCheckBackgroundStrokeUncheckedPointerOver" },
+							"Press": { "fullName": "CheckBoxCheckBackgroundStrokeUncheckedPressed" },
+							"Disabled": { "fullName": "CheckBoxCheckBackgroundStrokeUncheckedDisabled" }
+						}
+					},
+					"Selected": { "aliasOf": "Borderless.Stroke.Color",
+						"platform": {
+							"winui": {
+								"Rest": { "fullName": "CheckBoxCheckBackgroundStrokeChecked" },
+								"Hover": { "fullName": "CheckBoxCheckBackgroundStrokeCheckedPointerOver" },
+								"Press": { "fullName": "CheckBoxCheckBackgroundStrokeCheckedPressed" },
+								"Disabled": { "fullName": "CheckBoxCheckBackgroundStrokeCheckedDisabled" }
+							}
+						}
+					},
+					"Indeterminate": { "aliasOf": "Borderless.Stroke.Color",
+						"platform": {
+							"winui": {
+								"Rest": { "fullName": "CheckBoxCheckBackgroundStrokeIndeterminate" },
+								"Hover": { "fullName": "CheckBoxCheckBackgroundStrokeIndeterminatePointerOver" },
+								"Press": { "fullName": "CheckBoxCheckBackgroundStrokeIndeterminatePressed" },
+								"Disabled": { "fullName": "CheckBoxCheckBackgroundStrokeIndeterminateDisabled" }
+							}
+						}
+					}
+				},
+				"Width": { "aliasOf": "NeutralStroke1.Stroke.Width",
+					"platform": {
+						"winui": {
+							"fullName": "CheckBoxBorderThemeThickness"
+						}
+					} 
+				}
+			},
+			"Corner": { "aliasOf": "Control.Corner" }
+		}
+	},
+
+	"Slider": {
+		"Thumb": {
+			"Fill": {
+				"Color": { "aliasOf": "BrandBackground.Fill.Color" }
+			},
+			"Stroke": {
+				"Color": { "aliasOf": "Borderless.Stroke.Color" },
+				"Width": { "aliasOf": "Borderless.Stroke.Width" }
+			},
+			"Layout": {
+				"Width": { "value": 20 },
+				"Height": { "value": 20 }
+			},
+			"Corner": { "aliasOf": "Round.Corner" }
+		},
+		"Track": {
+			"Fill": {
+				"Color": { "Empty": { "aliasOf": "NeutralBackground2.Fill.Color" }, "Full": { "aliasOf": "NeutralStroke2.Stroke.Color" } }
+			},
+			"Layout": { "Height": { "value": 2 } }
+		},
+		"Ticks": {
+			"Fill": {
+				"Color": { "aliasOf": "NeutralForegroundInvertedAccessible.Fill.Color" }
+			},
+			"Layout": { "Height": { "value": 4 } }
+		}
 	}
 }

--- a/src/demo/fluentui.json
+++ b/src/demo/fluentui.json
@@ -6,23 +6,19 @@
 	"Global": {
 		"Color": {
 			"Brand": {
-				"Shade": {
-					"60": { "value": "#092c47" },
-					"50": { "value": "#043862" },
-					"40": { "value": "#004578" },
-					"30": { "value": "#004c87" },
-					"20": { "value": "#005a9e" },
-					"10": { "value": "#106ebe" }
-				},
+				"Shade60": { "value": "#092c47" },
+				"Shade50": { "value": "#043862" },
+				"Shade40": { "value": "#004578" },
+				"Shade30": { "value": "#004c87" },
+				"Shade20": { "value": "#005a9e" },
+				"Shade10": { "value": "#106ebe" },
 				"Primary": { "value": "#0078d4" },
-				"Tint": {
-					"10": { "value": "#2899f5" },
-					"20": { "value": "#3aa0f3" },
-					"30": { "value": "#6cb8f6" },
-					"40": { "value": "#c7e0f4" },
-					"50": { "value": "#deecf9" },
-					"60": { "value": "#eff6fc" }
-				}
+				"Tint10": { "value": "#2899f5" },
+				"Tint20": { "value": "#3aa0f3" },
+				"Tint30": { "value": "#6cb8f6" },
+				"Tint40": { "value": "#c7e0f4" },
+				"Tint50": { "value": "#deecf9" },
+				"Tint60": { "value": "#eff6fc" }
 			},
 			"Grey": { "generate": { "type": "lightness2to98by2", "value": "grey" } },
 			"HC": {
@@ -365,7 +361,6 @@
 			}
 		}
 	},
-	"TransparentBackgroundSelected": { "aliasOf": "TransparentBackground" },
 	"GhostBackground": {
 		"Fill": {
 			"Color": {
@@ -376,7 +371,6 @@
 			}
 		}
 	},
-	"GhostBackgroundSelected": { "aliasOf": "GhostBackground" },
 
 	"NeutralForeground1": {
 		"Fill": {
@@ -388,7 +382,6 @@
 			}
 		}
 	},
-	"NeutralForeground1Selected": { "aliasOf": "NeutralForeground1" },
 	"NeutralBackground1": {
 		"Fill": {
 			"Color": {
@@ -399,7 +392,6 @@
 			}
 		}
 	},
-	"NeutralBackground1Selected": { "aliasOf": "NeutralBackground1" },
 	"NeutralStroke1": {
 		"Stroke": {
 			"Color": {
@@ -411,7 +403,6 @@
 			"Width": { "aliasOf": "Global.Stroke.Width.Thin" }
 		}
 	},
-	"NeutralStroke1Selected": { "aliasOf": "NeutralStroke1" },
 
 	"NeutralForeground2": {
 		"Fill": {
@@ -423,18 +414,16 @@
 			}
 		}
 	},
-	"NeutralForeground2Selected": { "aliasOf": "NeutralForeground2" },
 	"NeutralForeground2Brand": {
 		"Fill": {
 			"Color": {
 				"Rest": { "aliasOf": "Global.Color.Grey.26" },
 				"Hover": { "aliasOf": "Global.Color.Brand.Primary" },
-				"Pressed": { "aliasOf": "Global.Color.Brand.Shade.10" },
+				"Pressed": { "aliasOf": "Global.Color.Brand.Shade10" },
 				"Disabled": { "aliasOf": "Global.Color.Grey.14" }
 			}
 		}
 	},
-	"NeutralForeground2BrandSelected": { "aliasOf": "NeutralForeground2Brand" },
 	"NeutralBackground2": {
 		"Fill": {
 			"Color": {
@@ -445,7 +434,6 @@
 			}
 		}
 	},
-	"NeutralBackground2Selected": { "aliasOf": "NeutralBackground2" },
 	"NeutralStroke2": {
 		"Stroke": {
 			"Color": {
@@ -457,7 +445,6 @@
 			"Width": { "aliasOf": "Global.Stroke.Width.Thin" }
 		}
 	},
-	"NeutralStroke2Selected": { "aliasOf": "NeutralStroke2" },
 	"NeutralForegroundInverted": {
 		"Fill": {
 			"Color": {
@@ -468,7 +455,6 @@
 			}
 		}
 	},
-	"NeutralForegroundInvertedSelected": { "aliasOf": "NeutralForegroundInverted" },
 	"NeutralForegroundInvertedAccessible": {
 		"Fill": {
 			"Color": {
@@ -479,16 +465,14 @@
 			}
 		}
 	},
-	"NeutralForegroundInvertedAccessibleSelected": { "aliasOf": "NeutralForegroundInvertedAccessible" },
 	"BrandBackground": {
 		"Fill": {
 			"Color": {
 				"Rest": { "aliasOf": "Global.Color.Brand.Primary" },
-				"Hover": { "aliasOf": "Global.Color.Brand.Shade.10" },
-				"Pressed": { "aliasOf": "Global.Color.Brand.Shade.40" },
+				"Hover": { "aliasOf": "Global.Color.Brand.Shade10" },
+				"Pressed": { "aliasOf": "Global.Color.Brand.Shade40" },
 				"Disabled": { "aliasOf": "Global.Color.Grey.94" }
 			}
 		}
-	},
-	"BrandBackgroundSelected": { "aliasOf": "BrandBackground" }
+	}
 }

--- a/src/demo/fluentui.json
+++ b/src/demo/fluentui.json
@@ -232,522 +232,263 @@
 			}
 		}
 	},
-	"Set": {
-		"Caption": {
-			"Font": {
-				"Family": { "aliasOf": "Global.Font.Family.Default" },
-				"Size": { "aliasOf": "Global.Font.Size.200" },
-				"Weight": { "aliasOf": "Global.Font.Weight.Regular" },
-				"LineHeight": { "aliasOf": "Global.Font.LineHeight.200" }
-			}
-		},
-		"Body": {
-			"Font": {
-				"Family": { "aliasOf": "Global.Font.Family.Default" },
-				"Size": { "aliasOf": "Global.Font.Size.300" },
-				"Weight": { "aliasOf": "Global.Font.Weight.Regular" },
-				"LineHeight": { "aliasOf": "Global.Font.LineHeight.300" }
-			}
-		},
-		"Subheadline": {
-			"Font": {
-				"Family": { "aliasOf": "Global.Font.Family.Default" },
-				"Size": { "aliasOf": "Global.Font.Size.400" },
-				"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
-				"LineHeight": { "aliasOf": "Global.Font.LineHeight.400" }
-			}
-		},
-		"Headline": {
-			"Font": {
-				"Family": { "aliasOf": "Global.Font.Family.Default" },
-				"Size": { "aliasOf": "Global.Font.Size.500" },
-				"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
-				"LineHeight": { "aliasOf": "Global.Font.LineHeight.500" }
-			}
-		},
-		"Title3": {
-			"Font": {
-				"Family": { "aliasOf": "Global.Font.Family.Default" },
-				"Size": { "aliasOf": "Global.Font.Size.600" },
-				"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
-				"LineHeight": { "aliasOf": "Global.Font.LineHeight.600" }
-			}
-		},
-		"Title2": {
-			"Font": {
-				"Family": { "aliasOf": "Global.Font.Family.Default" },
-				"Size": { "aliasOf": "Global.Font.Size.700" },
-				"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
-				"LineHeight": { "aliasOf": "Global.Font.LineHeight.700" }
-			}
-		},
-		"Title1": {
-			"Font": {
-				"Family": { "aliasOf": "Global.Font.Family.Default" },
-				"Size": { "aliasOf": "Global.Font.Size.800" },
-				"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
-				"LineHeight": { "aliasOf": "Global.Font.LineHeight.800" }
-			}
-		},
-		"LargeTitle": {
-			"Font": {
-				"Family": { "aliasOf": "Global.Font.Family.Default" },
-				"Size": { "aliasOf": "Global.Font.Size.900" },
-				"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
-				"LineHeight": { "aliasOf": "Global.Font.LineHeight.900" }
-			}
-		},
-		"Display": {
-			"Font": {
-				"Family": { "aliasOf": "Global.Font.Family.Default" },
-				"Size": { "aliasOf": "Global.Font.Size.1000" },
-				"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
-				"LineHeight": { "aliasOf": "Global.Font.LineHeight.1000" }
-			}
-		},
-		
-		"Square": {
-			"Corner": {
-				"Radius": { "aliasOf": "Global.Corner.Radius.None" }
-			}
-		},
-		"Icon": {
-			"Corner": {
-				"Radius": { "aliasOf": "Global.Corner.Radius.Medium" }
-			}
-		},
-		"Control": {
-			"Corner": {
-				"Radius": { "aliasOf": "Global.Corner.Radius.Medium" }
-			},
-			"Font": {
-				"Family": { "aliasOf": "Global.Font.Family.Default" },
-				"Size": { "aliasOf": "Global.Font.Size.300" },
-				"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
-				"LineHeight": { "aliasOf": "Global.Font.LineHeight.300" }
-			}
-		},
-		"Surface": {
-			"Corner": {
-				"Radius": { "aliasOf": "Global.Corner.Radius.Medium" }
-			}
-		},
-		"Illustration": {
-			"Corner": {
-				"Radius": { "aliasOf": "Global.Corner.Radius.ExtraLarge" }
-			}
-		},
-		"Round": {
-			"Corner": {
-				"Radius": { "aliasOf": "Global.Corner.Radius.Circle" }
-			}
-		},
 
-		"Borderless": {
-			"Stroke": {
-				"Color": {
-					"Rest": { "value": "transparent" },
-					"Hover": { "value": "transparent" },
-					"Pressed": { "value": "transparent" },
-					"Disabled": { "value": "transparent" }
-				},
-				"Width": { "aliasOf": "Global.Stroke.Width.Thin" },
-				"Alignment": { "value": "inner" }
-			}
-		},
-		"TransparentBackground": {
-			"Fill": {
-				"Color": {
-					"Rest": { "value": "transparent" },
-					"Hover": { "value": "transparent" },
-					"Pressed": { "value": "transparent" },
-					"Disabled": { "value": "transparent" }
-				}
-			}
-		},
-		"TransparentBackgroundSelected": { "aliasOf": "Set.TransparentBackground" },
-		"GhostBackground": {
-			"Fill": {
-				"Color": {
-					"Rest": { "value": "transparent" },
-					"Hover": { "aliasOf": "Global.Color.Grey.96" },
-					"Pressed": { "aliasOf": "Global.Color.Grey.88" },
-					"Disabled": { "aliasOf": "Global.Color.Grey.94" }
-				}
-			}
-		},
-		"GhostBackgroundSelected": { "aliasOf": "Set.GhostBackground" },
-
-		"NeutralForeground1": {
-			"Fill": {
-				"Color": {
-					"Rest": { "aliasOf": "Global.Color.Grey.14" },
-					"Hover": { "aliasOf": "Global.Color.Grey.14" },
-					"Pressed": { "aliasOf": "Global.Color.Grey.14" },
-					"Disabled": { "aliasOf": "Global.Color.Grey.14" }
-				}
-			}
-		},
-		"NeutralForeground1Selected": { "aliasOf": "Set.NeutralForeground1" },
-		"NeutralBackground1": {
-			"Fill": {
-				"Color": {
-					"Rest": { "aliasOf": "Global.Color.White" },
-					"Hover": { "aliasOf": "Global.Color.Grey.96" },
-					"Pressed": { "aliasOf": "Global.Color.Grey.88" },
-					"Disabled": { "aliasOf": "Global.Color.Grey.94" }
-				}
-			}
-		},
-		"NeutralBackground1Selected": { "aliasOf": "Set.NeutralBackground1" },
-		"NeutralStroke1": {
-			"Stroke": {
-				"Color": {
-					"Rest": { "aliasOf": "Global.Color.Grey.82" },
-					"Hover": { "aliasOf": "Global.Color.Grey.78" },
-					"Pressed": { "aliasOf": "Global.Color.Grey.70" },
-					"Disabled": { "aliasOf": "Global.Color.Grey.88" }
-				},
-				"Width": { "aliasOf": "Global.Stroke.Width.Thin" }
-			}
-		},
-		"NeutralStroke1Selected": { "aliasOf": "Set.NeutralStroke1" },
-
-		"NeutralForeground2": {
-			"Fill": {
-				"Color": {
-					"Rest": { "aliasOf": "Global.Color.Grey.26" },
-					"Hover": { "aliasOf": "Global.Color.Grey.14" },
-					"Pressed": { "aliasOf": "Global.Color.Grey.14" },
-					"Disabled": { "aliasOf": "Global.Color.Grey.14" }
-				}
-			}
-		},
-		"NeutralForeground2Selected": { "aliasOf": "Set.NeutralForeground2" },
-		"NeutralForeground2Brand": {
-			"Fill": {
-				"Color": {
-					"Rest": { "aliasOf": "Global.Color.Grey.26" },
-					"Hover": { "aliasOf": "Global.Color.Brand.Primary" },
-					"Pressed": { "aliasOf": "Global.Color.Brand.Shade.10" },
-					"Disabled": { "aliasOf": "Global.Color.Grey.14" }
-				}
-			}
-		},
-		"NeutralForeground2BrandSelected": { "aliasOf": "Set.NeutralForeground2Brand" },
-		"NeutralBackground2": {
-			"Fill": {
-				"Color": {
-					"Rest": { "aliasOf": "Global.Color.Grey.98" },
-					"Hover": { "aliasOf": "Global.Color.Grey.94" },
-					"Pressed": { "aliasOf": "Global.Color.Grey.86" },
-					"Disabled": { "aliasOf": "Global.Color.Grey.94" }
-				}
-			}
-		},
-		"NeutralBackground2Selected": { "aliasOf": "Set.NeutralBackground2" },
-		"NeutralStroke2": {
-			"Stroke": {
-				"Color": {
-					"Rest": { "aliasOf": "Global.Color.Grey.88" },
-					"Hover": { "aliasOf": "Global.Color.Grey.88" },
-					"Pressed": { "aliasOf": "Global.Color.Grey.88" },
-					"Disabled": { "aliasOf": "Global.Color.Grey.88" }
-				},
-				"Width": { "aliasOf": "Global.Stroke.Width.Thin" }
-			}
-		},
-		"NeutralStroke2Selected": { "aliasOf": "Set.NeutralStroke2" },
-		"NeutralForegroundInverted": {
-			"Fill": {
-				"Color": {
-					"Rest": { "aliasOf": "Global.Color.White" },
-					"Hover": { "aliasOf": "Global.Color.White" },
-					"Pressed": { "aliasOf": "Global.Color.White" },
-					"Disabled": { "aliasOf": "Global.Color.White" }
-				}
-			}
-		},
-		"NeutralForegroundInvertedSelected": { "aliasOf": "Set.NeutralForegroundInverted" },
-		"NeutralForegroundInvertedAccessible": {
-			"Fill": {
-				"Color": {
-					"Rest": { "aliasOf": "Global.Color.White" },
-					"Hover": { "aliasOf": "Global.Color.White" },
-					"Pressed": { "aliasOf": "Global.Color.White" },
-					"Disabled": { "aliasOf": "Global.Color.White" }
-				}
-			}
-		},
-		"NeutralForegroundInvertedAccessibleSelected": { "aliasOf": "Set.NeutralForegroundInvertedAccessible" },
-		"BrandBackground": {
-			"Fill": {
-				"Color": {
-					"Rest": { "aliasOf": "Global.Color.Brand.Primary" },
-					"Hover": { "aliasOf": "Global.Color.Brand.Shade.10" },
-					"Pressed": { "aliasOf": "Global.Color.Brand.Shade.40" },
-					"Disabled": { "aliasOf": "Global.Color.Grey.94" }
-				}
-			}
-		},
-		"BrandBackgroundSelected": { "aliasOf": "Set.BrandBackground" }
+	"Caption": {
+		"Font": {
+			"Family": { "aliasOf": "Global.Font.Family.Default" },
+			"Size": { "aliasOf": "Global.Font.Size.200" },
+			"Weight": { "aliasOf": "Global.Font.Weight.Regular" },
+			"LineHeight": { "aliasOf": "Global.Font.LineHeight.200" }
+		}
 	},
-
-	"Button": {
-		"Content": {
-			"Font": { "aliasOf": "Set.Control.Font" },
-			"Fill": { "Color": { "aliasOf": "Set.NeutralForeground1.Fill.Color", "Selected": { "aliasOf": "Set.NeutralForeground1Selected.Fill.Color" } } }
+	"Body": {
+		"Font": {
+			"Family": { "aliasOf": "Global.Font.Family.Default" },
+			"Size": { "aliasOf": "Global.Font.Size.300" },
+			"Weight": { "aliasOf": "Global.Font.Weight.Regular" },
+			"LineHeight": { "aliasOf": "Global.Font.LineHeight.300" }
+		}
+	},
+	"Subheadline": {
+		"Font": {
+			"Family": { "aliasOf": "Global.Font.Family.Default" },
+			"Size": { "aliasOf": "Global.Font.Size.400" },
+			"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
+			"LineHeight": { "aliasOf": "Global.Font.LineHeight.400" }
+		}
+	},
+	"Headline": {
+		"Font": {
+			"Family": { "aliasOf": "Global.Font.Family.Default" },
+			"Size": { "aliasOf": "Global.Font.Size.500" },
+			"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
+			"LineHeight": { "aliasOf": "Global.Font.LineHeight.500" }
+		}
+	},
+	"Title3": {
+		"Font": {
+			"Family": { "aliasOf": "Global.Font.Family.Default" },
+			"Size": { "aliasOf": "Global.Font.Size.600" },
+			"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
+			"LineHeight": { "aliasOf": "Global.Font.LineHeight.600" }
+		}
+	},
+	"Title2": {
+		"Font": {
+			"Family": { "aliasOf": "Global.Font.Family.Default" },
+			"Size": { "aliasOf": "Global.Font.Size.700" },
+			"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
+			"LineHeight": { "aliasOf": "Global.Font.LineHeight.700" }
+		}
+	},
+	"Title1": {
+		"Font": {
+			"Family": { "aliasOf": "Global.Font.Family.Default" },
+			"Size": { "aliasOf": "Global.Font.Size.800" },
+			"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
+			"LineHeight": { "aliasOf": "Global.Font.LineHeight.800" }
+		}
+	},
+	"LargeTitle": {
+		"Font": {
+			"Family": { "aliasOf": "Global.Font.Family.Default" },
+			"Size": { "aliasOf": "Global.Font.Size.900" },
+			"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
+			"LineHeight": { "aliasOf": "Global.Font.LineHeight.900" }
+		}
+	},
+	"Display": {
+		"Font": {
+			"Family": { "aliasOf": "Global.Font.Family.Default" },
+			"Size": { "aliasOf": "Global.Font.Size.1000" },
+			"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
+			"LineHeight": { "aliasOf": "Global.Font.LineHeight.1000" }
+		}
+	},
+	
+	"Square": {
+		"Corner": {
+			"Radius": { "aliasOf": "Global.Corner.Radius.None" }
+		}
+	},
+	"Icon": {
+		"Corner": {
+			"Radius": { "aliasOf": "Global.Corner.Radius.Medium" }
+		}
+	},
+	"Control": {
+		"Corner": {
+			"Radius": { "aliasOf": "Global.Corner.Radius.Medium" }
 		},
-		"Icon": {
-			"Fill": { "Color": { "aliasOf": "Set.NeutralForeground1.Fill.Color", "Selected": { "aliasOf": "Set.NeutralForeground1Selected.Fill.Color" } } }
-		},
-		"Base": {
-			"Fill": { "Color": { "aliasOf": "Set.NeutralBackground1.Fill.Color", "Selected": { "aliasOf": "Set.NeutralBackground1Selected.Fill.Color" } } },
-			"Stroke": {
-				"Color": { "aliasOf": "Set.NeutralStroke1.Stroke.Color", "Selected": { "aliasOf": "Set.NeutralStroke1Selected.Stroke.Color" } },
-				"Width": { "aliasOf": "Set.NeutralStroke1.Stroke.Width", "Selected": { "aliasOf": "Set.NeutralStroke1Selected.Stroke.Width" } }
-			},
-			"Corner": { "aliasOf": "Set.Control.Corner" },
-			"Layout": { "Padding": { "value": [ 7, 15, 7, 15 ] } }
+		"Font": {
+			"Family": { "aliasOf": "Global.Font.Family.Default" },
+			"Size": { "aliasOf": "Global.Font.Size.300" },
+			"Weight": { "aliasOf": "Global.Font.Weight.Semibold" },
+			"LineHeight": { "aliasOf": "Global.Font.LineHeight.300" }
+		}
+	},
+	"Surface": {
+		"Corner": {
+			"Radius": { "aliasOf": "Global.Corner.Radius.Medium" }
+		}
+	},
+	"Illustration": {
+		"Corner": {
+			"Radius": { "aliasOf": "Global.Corner.Radius.ExtraLarge" }
+		}
+	},
+	"Round": {
+		"Corner": {
+			"Radius": { "aliasOf": "Global.Corner.Radius.Circle" }
 		}
 	},
 
-	"ButtonPrimary": {
-		"Content": {
-			"Font": { "aliasOf": "Set.Control.Font" },
-			"Fill": { "Color": { "aliasOf": "Set.NeutralForegroundInvertedAccessible.Fill.Color", "Selected": { "aliasOf": "Set.NeutralForegroundInvertedAccessibleSelected.Fill.Color" } } }
-		},
-		"Icon": {
-			"Fill": { "Color": { "aliasOf": "Set.NeutralForegroundInvertedAccessible.Fill.Color", "Selected": { "aliasOf": "Set.NeutralForegroundInvertedAccessibleSelected.Fill.Color" } } }
-		},
-		"Base": {
-			"Fill": { "Color": { "aliasOf": "Set.BrandBackground.Fill.Color", "Selected": { "aliasOf": "Set.BrandBackgroundSelected.Fill.Color" } } },
-			"Stroke": {
-				"Color": { "aliasOf": "Set.Borderless.Stroke.Color", "Selected": { "aliasOf": "Set.Borderless.Stroke.Color" } },
-				"Width": { "aliasOf": "Set.Borderless.Stroke.Width", "Selected": { "aliasOf": "Set.Borderless.Stroke.Width" } }
+	"Borderless": {
+		"Stroke": {
+			"Color": {
+				"Rest": { "value": "transparent" },
+				"Hover": { "value": "transparent" },
+				"Pressed": { "value": "transparent" },
+				"Disabled": { "value": "transparent" }
 			},
-			"Corner": { "aliasOf": "Set.Control.Corner" },
-			"Layout": { "Padding": { "value": [ 7, 15, 7, 15 ] } }
+			"Width": { "aliasOf": "Global.Stroke.Width.Thin" },
+			"Alignment": { "value": "inner" }
 		}
 	},
-
-	"ButtonOutline": {
-		"Content": {
-			"Font": { "aliasOf": "Set.Control.Font" },
-			"Fill": { "Color": { "aliasOf": "Set.NeutralForeground1.Fill.Color", "Selected": { "aliasOf": "Set.NeutralForeground1Selected.Fill.Color" } } }
-		},
-		"Icon": {
-			"Fill": { "Color": { "aliasOf": "Set.NeutralForeground1.Fill.Color", "Selected": { "aliasOf": "Set.NeutralForeground1Selected.Fill.Color" } } }
-		},
-		"Base": {
-			"Fill": { "Color": { "aliasOf": "Set.TransparentBackground.Fill.Color", "Selected": { "aliasOf": "Set.TransparentBackgroundSelected.Fill.Color" } } },
-			"Stroke": {
-				"Color": { "aliasOf": "Set.NeutralStroke1.Stroke.Color", "Selected": { "aliasOf": "Set.NeutralStroke1.Stroke.Color" } },
-				"Width": { "aliasOf": "Set.NeutralStroke1.Stroke.Width", "Selected": { "aliasOf": "Set.NeutralStroke1.Stroke.Width" } }
-			},
-			"Corner": { "aliasOf": "Set.Control.Corner" },
-			"Layout": { "Padding": { "value": [7, 15, 7, 15] } }
-		}
-	},
-
-	"ButtonGhost": {
-		"Content": {
-			"Font": { "aliasOf": "Set.Body.Font" },
-			"Fill": { "Color": { "aliasOf": "Set.NeutralForeground2Brand.Fill.Color", "Selected": { "aliasOf": "Set.NeutralForeground2BrandSelected.Fill.Color" } } }
-		},
-		"Icon": {
-			"Fill": { "Color": { "aliasOf": "Set.NeutralForeground2Brand.Fill.Color", "Selected": { "aliasOf": "Set.NeutralForeground2BrandSelected.Fill.Color" } } }
-		},
-		"Base": {
-			"Fill": { "Color": { "aliasOf": "Set.GhostBackground.Fill.Color", "Selected": { "aliasOf": "Set.GhostBackgroundSelected.Fill.Color" } } },
-			"Stroke": {
-				"Color": { "aliasOf": "Set.Borderless.Stroke.Color", "Selected": { "aliasOf": "Set.Borderless.Stroke.Color" } },
-				"Width": { "aliasOf": "Set.Borderless.Stroke.Width", "Selected": { "aliasOf": "Set.Borderless.Stroke.Width" } }
-			},
-			"Corner": { "aliasOf": "Set.Control.Corner" },
-			"Layout": { "Padding": { "value": [ 7, 15, 7, 15 ] } }
-		}
-	},
-
-	"CheckBox": {
-		"Text": {
-			"Font": { "aliasOf": "Set.Body.Font" },
-			"Fill": {
-				"Color": {
-					"aliasOf": "Set.NeutralForegroundInvertedAccessible.Fill.Color",
-					"platform": {
-						"winui": {
-							"Rest": { "fullName": "CheckBoxForegroundUnchecked" },
-							"Hover": { "fullName": "CheckBoxForegroundUncheckedPointerOver" },
-							"Press": { "fullName": "CheckBoxForegroundUncheckedPressed" },
-							"Disabled": { "fullName": "CheckBoxForegroundUncheckedDisabled" }
-						}
-					},
-					"Selected": {
-						"aliasOf": "Set.NeutralForegroundInvertedAccessible.Fill.Color",
-						"platform": {
-							"winui": {
-								"Rest": { "fullName": "CheckBoxForegroundChecked" },
-								"Hover": { "fullName": "CheckBoxForegroundCheckedPointerOver" },
-								"Press": { "fullName": "CheckBoxForegroundCheckedPressed" },
-								"Disabled": { "fullName": "CheckBoxForegroundCheckedDisabled" }
-							}
-						}
-					},
-					"Indeterminate": {
-						"aliasOf": "Set.NeutralForegroundInvertedAccessible.Fill.Color",
-						"platform": {
-							"winui": {
-								"Rest": { "fullName": "CheckBoxForegroundIndeterminate" },
-								"Hover": { "fullName": "CheckBoxForegroundIndeterminatePointerOver" },
-								"Press": { "fullName": "CheckBoxForegroundIndeterminatePressed" },
-								"Disabled": { "fullName": "CheckBoxForegroundIndeterminateDisabled" }
-							}
-						}
-					}
-				}
+	"TransparentBackground": {
+		"Fill": {
+			"Color": {
+				"Rest": { "value": "transparent" },
+				"Hover": { "value": "transparent" },
+				"Pressed": { "value": "transparent" },
+				"Disabled": { "value": "transparent" }
 			}
-		},
-		"Check": {
-			"Fill": {
-				"Color": {
-					"aliasOf": "Set.NeutralForegroundInvertedAccessible.Fill.Color",
-					"platform": {
-						"winui": {
-							"Rest": { "fullName": "CheckBoxCheckGlyphForegroundUnchecked" },
-							"Hover": { "fullName": "CheckBoxCheckGlyphForegroundUncheckedPointerOver" },
-							"Press": { "fullName": "CheckBoxCheckGlyphForegroundUncheckedPressed" },
-							"Disabled": { "fullName": "CheckBoxCheckGlyphForegroundUncheckedDisabled" }
-						}
-					},
-					"Selected": {
-						"aliasOf": "Set.NeutralForegroundInvertedAccessible.Fill.Color",
-						"platform": {
-							"winui": {
-								"Rest": { "fullName": "CheckBoxCheckGlyphForegroundChecked" },
-								"Hover": { "fullName": "CheckBoxCheckGlyphForegroundCheckedPointerOver" },
-								"Press": { "fullName": "CheckBoxCheckGlyphForegroundCheckedPressed" },
-								"Disabled": { "fullName": "CheckBoxCheckGlyphForegroundCheckedDisabled" }
-							}
-						}
-					},
-					"Indeterminate": {
-						"aliasOf": "Set.NeutralForegroundInvertedAccessible.Fill.Color",
-						"platform": {
-							"winui": {
-								"Rest": { "fullName": "CheckBoxCheckGlyphForegroundIndeterminate" },
-								"Hover": { "fullName": "CheckBoxCheckGlyphForegroundIndeterminatePointerOver" },
-								"Press": { "fullName": "CheckBoxCheckGlyphForegroundIndeterminatePressed" },
-								"Disabled": { "fullName": "CheckBoxCheckGlyphForegroundIndeterminateDisabled" }
-							}
-						}
-					}
-				}
-			}
-		},
-		"Box": {
-			"Fill": {
-				"Color": {
-					"aliasOf": "Set.TransparentBackground.Fill.Color",
-					"platform": {
-						"winui": {
-							"Rest": { "fullName": "CheckBoxCheckBackgroundFillUnchecked" },
-							"Hover": { "fullName": "CheckBoxCheckBackgroundFillUncheckedPointerOver" },
-							"Press": { "fullName": "CheckBoxCheckBackgroundFillUncheckedPressed" },
-							"Disabled": { "fullName": "CheckBoxCheckBackgroundFillUncheckedDisabled" }
-						}
-					},
-					"Selected": { "aliasOf": "Set.BrandBackground.Fill.Color",
-						"platform": {
-							"winui": {
-								"Rest": { "fullName": "CheckBoxCheckBackgroundFillChecked" },
-								"Hover": { "fullName": "CheckBoxCheckBackgroundFillCheckedPointerOver" },
-								"Press": { "fullName": "CheckBoxCheckBackgroundFillCheckedPressed" },
-								"Disabled": { "fullName": "CheckBoxCheckBackgroundFillCheckedDisabled" }
-							}
-						} },
-					"Indeterminate": { "aliasOf": "Set.BrandBackground.Fill.Color",
-						"platform": {
-							"winui": {
-								"Rest": { "fullName": "CheckBoxCheckBackgroundFillIndeterminate" },
-								"Hover": { "fullName": "CheckBoxCheckBackgroundFillIndeterminatePointerOver" },
-								"Press": { "fullName": "CheckBoxCheckBackgroundFillIndeterminatePressed" },
-								"Disabled": { "fullName": "CheckBoxCheckBackgroundFillIndeterminateDisabled" }
-							}
-						} }
-				}
-			},
-			"Stroke": {
-				"Color": {
-					"aliasOf": "Set.NeutralStroke1.Stroke.Color",
-					"platform": {
-						"winui": {
-							"Rest": { "fullName": "CheckBoxCheckBackgroundStrokeUnchecked" },
-							"Hover": { "fullName": "CheckBoxCheckBackgroundStrokeUncheckedPointerOver" },
-							"Press": { "fullName": "CheckBoxCheckBackgroundStrokeUncheckedPressed" },
-							"Disabled": { "fullName": "CheckBoxCheckBackgroundStrokeUncheckedDisabled" }
-						}
-					},
-					"Selected": { "aliasOf": "Set.Borderless.Stroke.Color",
-						"platform": {
-							"winui": {
-								"Rest": { "fullName": "CheckBoxCheckBackgroundStrokeChecked" },
-								"Hover": { "fullName": "CheckBoxCheckBackgroundStrokeCheckedPointerOver" },
-								"Press": { "fullName": "CheckBoxCheckBackgroundStrokeCheckedPressed" },
-								"Disabled": { "fullName": "CheckBoxCheckBackgroundStrokeCheckedDisabled" }
-							}
-						}
-					},
-					"Indeterminate": { "aliasOf": "Set.Borderless.Stroke.Color",
-						"platform": {
-							"winui": {
-								"Rest": { "fullName": "CheckBoxCheckBackgroundStrokeIndeterminate" },
-								"Hover": { "fullName": "CheckBoxCheckBackgroundStrokeIndeterminatePointerOver" },
-								"Press": { "fullName": "CheckBoxCheckBackgroundStrokeIndeterminatePressed" },
-								"Disabled": { "fullName": "CheckBoxCheckBackgroundStrokeIndeterminateDisabled" }
-							}
-						}
-					}
-				},
-				"Width": { "aliasOf": "Set.NeutralStroke1.Stroke.Width",
-					"platform": {
-						"winui": {
-							"fullName": "CheckBoxBorderThemeThickness"
-						}
-					} 
-				}
-			},
-			"Corner": { "aliasOf": "Set.Control.Corner" }
 		}
 	},
-
-	"Slider": {
-		"Thumb": {
-			"Fill": {
-				"Color": { "aliasOf": "Set.BrandBackground.Fill.Color" }
-			},
-			"Stroke": {
-				"Color": { "aliasOf": "Set.Borderless.Stroke.Color" },
-				"Width": { "aliasOf": "Set.Borderless.Stroke.Width" }
-			},
-			"Layout": {
-				"Width": { "value": 20 },
-				"Height": { "value": 20 }
-			},
-			"Corner": { "aliasOf": "Set.Round.Corner" }
-		},
-		"Track": {
-			"Fill": {
-				"Color": { "Empty": { "aliasOf": "Set.NeutralBackground2.Fill.Color" }, "Full": { "aliasOf": "Set.NeutralStroke2.Stroke.Color" } }
-			},
-			"Layout": { "Height": { "value": 2 } }
-		},
-		"Ticks": {
-			"Fill": {
-				"Color": { "aliasOf": "Set.NeutralForegroundInvertedAccessible.Fill.Color" }
-			},
-			"Layout": { "Height": { "value": 4 } }
+	"TransparentBackgroundSelected": { "aliasOf": "TransparentBackground" },
+	"GhostBackground": {
+		"Fill": {
+			"Color": {
+				"Rest": { "value": "transparent" },
+				"Hover": { "aliasOf": "Global.Color.Grey.96" },
+				"Pressed": { "aliasOf": "Global.Color.Grey.88" },
+				"Disabled": { "aliasOf": "Global.Color.Grey.94" }
+			}
 		}
-	}
+	},
+	"GhostBackgroundSelected": { "aliasOf": "GhostBackground" },
 
+	"NeutralForeground1": {
+		"Fill": {
+			"Color": {
+				"Rest": { "aliasOf": "Global.Color.Grey.14" },
+				"Hover": { "aliasOf": "Global.Color.Grey.14" },
+				"Pressed": { "aliasOf": "Global.Color.Grey.14" },
+				"Disabled": { "aliasOf": "Global.Color.Grey.14" }
+			}
+		}
+	},
+	"NeutralForeground1Selected": { "aliasOf": "NeutralForeground1" },
+	"NeutralBackground1": {
+		"Fill": {
+			"Color": {
+				"Rest": { "aliasOf": "Global.Color.White" },
+				"Hover": { "aliasOf": "Global.Color.Grey.96" },
+				"Pressed": { "aliasOf": "Global.Color.Grey.88" },
+				"Disabled": { "aliasOf": "Global.Color.Grey.94" }
+			}
+		}
+	},
+	"NeutralBackground1Selected": { "aliasOf": "NeutralBackground1" },
+	"NeutralStroke1": {
+		"Stroke": {
+			"Color": {
+				"Rest": { "aliasOf": "Global.Color.Grey.82" },
+				"Hover": { "aliasOf": "Global.Color.Grey.78" },
+				"Pressed": { "aliasOf": "Global.Color.Grey.70" },
+				"Disabled": { "aliasOf": "Global.Color.Grey.88" }
+			},
+			"Width": { "aliasOf": "Global.Stroke.Width.Thin" }
+		}
+	},
+	"NeutralStroke1Selected": { "aliasOf": "NeutralStroke1" },
+
+	"NeutralForeground2": {
+		"Fill": {
+			"Color": {
+				"Rest": { "aliasOf": "Global.Color.Grey.26" },
+				"Hover": { "aliasOf": "Global.Color.Grey.14" },
+				"Pressed": { "aliasOf": "Global.Color.Grey.14" },
+				"Disabled": { "aliasOf": "Global.Color.Grey.14" }
+			}
+		}
+	},
+	"NeutralForeground2Selected": { "aliasOf": "NeutralForeground2" },
+	"NeutralForeground2Brand": {
+		"Fill": {
+			"Color": {
+				"Rest": { "aliasOf": "Global.Color.Grey.26" },
+				"Hover": { "aliasOf": "Global.Color.Brand.Primary" },
+				"Pressed": { "aliasOf": "Global.Color.Brand.Shade.10" },
+				"Disabled": { "aliasOf": "Global.Color.Grey.14" }
+			}
+		}
+	},
+	"NeutralForeground2BrandSelected": { "aliasOf": "NeutralForeground2Brand" },
+	"NeutralBackground2": {
+		"Fill": {
+			"Color": {
+				"Rest": { "aliasOf": "Global.Color.Grey.98" },
+				"Hover": { "aliasOf": "Global.Color.Grey.94" },
+				"Pressed": { "aliasOf": "Global.Color.Grey.86" },
+				"Disabled": { "aliasOf": "Global.Color.Grey.94" }
+			}
+		}
+	},
+	"NeutralBackground2Selected": { "aliasOf": "NeutralBackground2" },
+	"NeutralStroke2": {
+		"Stroke": {
+			"Color": {
+				"Rest": { "aliasOf": "Global.Color.Grey.88" },
+				"Hover": { "aliasOf": "Global.Color.Grey.88" },
+				"Pressed": { "aliasOf": "Global.Color.Grey.88" },
+				"Disabled": { "aliasOf": "Global.Color.Grey.88" }
+			},
+			"Width": { "aliasOf": "Global.Stroke.Width.Thin" }
+		}
+	},
+	"NeutralStroke2Selected": { "aliasOf": "NeutralStroke2" },
+	"NeutralForegroundInverted": {
+		"Fill": {
+			"Color": {
+				"Rest": { "aliasOf": "Global.Color.White" },
+				"Hover": { "aliasOf": "Global.Color.White" },
+				"Pressed": { "aliasOf": "Global.Color.White" },
+				"Disabled": { "aliasOf": "Global.Color.White" }
+			}
+		}
+	},
+	"NeutralForegroundInvertedSelected": { "aliasOf": "NeutralForegroundInverted" },
+	"NeutralForegroundInvertedAccessible": {
+		"Fill": {
+			"Color": {
+				"Rest": { "aliasOf": "Global.Color.White" },
+				"Hover": { "aliasOf": "Global.Color.White" },
+				"Pressed": { "aliasOf": "Global.Color.White" },
+				"Disabled": { "aliasOf": "Global.Color.White" }
+			}
+		}
+	},
+	"NeutralForegroundInvertedAccessibleSelected": { "aliasOf": "NeutralForegroundInvertedAccessible" },
+	"BrandBackground": {
+		"Fill": {
+			"Color": {
+				"Rest": { "aliasOf": "Global.Color.Brand.Primary" },
+				"Hover": { "aliasOf": "Global.Color.Brand.Shade.10" },
+				"Pressed": { "aliasOf": "Global.Color.Brand.Shade.40" },
+				"Disabled": { "aliasOf": "Global.Color.Grey.94" }
+			}
+		}
+	},
+	"BrandBackgroundSelected": { "aliasOf": "BrandBackground" }
 }

--- a/src/demo/w3c/dark.tokens.json
+++ b/src/demo/w3c/dark.tokens.json
@@ -1,992 +1,990 @@
 {
-	"Neutral": {
-		"NeutralForeground1": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"NeutralForeground2": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.84}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"BrandHover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.100}"
-					},
-					"BrandPressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.90}"
-					},
-					"BrandSelected": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.100}"
-					}
-				}
-			}
-		},
-		"NeutralForeground3": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.68}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.84}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.84}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.84}"
-					},
-					"BrandHover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.100}"
-					},
-					"BrandPressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.90}"
-					},
-					"BrandSelected": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.100}"
-					}
-				}
-			}
-		},
-		"NeutralForeground4": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.60}"
-					}
-				}
-			}
-		},
-		"NeutralForegroundDisabled": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.36}"
-					}
-				}
-			}
-		},
-		"NeutralForegroundInvertedDisabled": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.WhiteAlpha.40}"
-					}
-				}
-			}
-		},
-		"BrandForegroundLink": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.100}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.110}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.90}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.100}"
-					}
-				}
-			}
-		},
-		"NeutralForeground2Link": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.84}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"CompoundBrandForeground1": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.100}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.110}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.90}"
-					}
-				}
-			}
-		},
-		"BrandForeground1": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.100}"
-					}
-				}
-			}
-		},
-		"BrandForeground2": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.110}"
-					}
-				}
-			}
-		},
-		"NeutralForeground1Static": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					}
-				}
-			}
-		},
-		"NeutralForegroundStaticInverted": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"NeutralForegroundInverted": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					}
-				}
-			}
-		},
-		"NeutralForegroundInverted2": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					}
-				}
-			}
-		},
-		"NeutralForegroundOnBrand": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"NeutralForegroundInvertedLink": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"BrandForegroundInverted": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.70}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.60}"
-					}
-				}
-			}
-		},
-		"BrandForegroundOnLight": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.70}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.50}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.60}"
-					}
-				}
-			}
-		},
-		"NeutralBackground1": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.16}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.24}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.12}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.22}"
-					}
-				}
-			}
-		},
-		"NeutralBackground2": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.12}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.20}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.8}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.18}"
-					}
-				}
-			}
-		},
-		"NeutralBackground3": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.8}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.16}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.4}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					}
-				}
-			}
-		},
-		"NeutralBackground4": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.4}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.12}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Black}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.10}"
-					}
-				}
-			}
-		},
-		"NeutralBackground5": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Black}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.8}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.2}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.6}"
-					}
-				}
-			}
-		},
-		"NeutralBackground6": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.20}"
-					}
-				}
-			}
-		},
-		"NeutralBackgroundInverted": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"NeutralBackgroundStatic": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.24}"
-					}
-				}
-			}
-		},
-		"SubtleBackground": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000000"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.22}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.18}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.20}"
-					},
-					"LightAlphaHover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey14Alpha.80}"
-					},
-					"LightAlphaPressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey14Alpha.50}"
-					},
-					"LightAlphaSelected": {
-						"$type": "color",
-						"$value": "#00000000"
-					}
-				}
-			}
-		},
-		"SubtleBackgroundInverted": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000000"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.BlackAlpha.10}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.BlackAlpha.30}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.BlackAlpha.20}"
-					}
-				}
-			}
-		},
-		"TransparentBackground": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000000"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "#00000000"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "#00000000"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "#00000000"
-					}
-				}
-			}
-		},
-		"NeutralBackgroundDisabled": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.8}"
-					}
-				}
-			}
-		},
-		"NeutralBackgroundInvertedDisabled": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.WhiteAlpha.10}"
-					}
-				}
-			}
-		},
-		"NeutralStencil1": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.34}"
-					}
-				}
-			}
-		},
-		"NeutralStencil2": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.20}"
-					}
-				}
-			}
-		},
-		"NeutralStencil1Alpha": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.WhiteAlpha.10}"
-					}
-				}
-			}
-		},
-		"NeutralStencil2Alpha": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.WhiteAlpha.5}"
-					}
-				}
-			}
-		},
-		"BackgroundOverlay": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.BlackAlpha.50}"
-					}
-				}
-			}
-		},
-		"ScrollbarOverlay": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.WhiteAlpha.60}"
-					}
-				}
-			}
-		},
-		"BrandBackground": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.70}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.40}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.60}"
-					}
-				}
-			}
-		},
-		"CompoundBrandBackground": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.100}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.110}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.90}"
-					}
-				}
-			}
-		},
-		"BrandBackgroundStatic": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					}
-				}
-			}
-		},
-		"BrandBackground2": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.40}"
-					}
-				}
-			}
-		},
-		"BrandBackgroundInverted": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.160}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.140}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.150}"
-					}
-				}
-			}
-		},
-		"NeutralStrokeAccessible": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.68}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.74}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.70}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.100}"
-					}
-				}
-			}
-		},
-		"NeutralStroke1": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.40}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.46}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.42}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.44}"
-					}
-				}
-			}
-		},
-		"NeutralStroke2": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.32}"
-					}
-				}
-			}
-		},
-		"NeutralStroke3": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.24}"
-					}
-				}
-			}
-		},
-		"NeutralStrokeOnBrand": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.16}"
-					}
-				}
-			}
-		},
-		"NeutralStrokeOnBrand2": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"BrandStroke1": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.100}"
-					}
-				}
-			}
-		},
-		"BrandStroke2": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.50}"
-					}
-				}
-			}
-		},
-		"CompoundBrandStroke": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.100}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.110}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.90}"
-					}
-				}
-			}
-		},
-		"NeutralStrokeDisabled": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.26}"
-					}
-				}
-			}
-		},
-		"NeutralStrokeInvertedDisabled": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.WhiteAlpha.40}"
-					}
-				}
-			}
-		},
-		"TransparentStroke": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000000"
-					}
-				}
-			}
-		},
-		"TransparentStrokeInteractive": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000000"
-					}
-				}
-			}
-		},
-		"TransparentStrokeDisabled": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000000"
-					}
-				}
-			}
-		},
-		"StrokeFocus1": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Black}"
-					}
-				}
-			}
-		},
-		"StrokeFocus2": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"NeutralShadowAmbient": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#0000003d"
-					}
-				}
-			}
-		},
-		"NeutralShadowKey": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000047"
-					}
-				}
-			}
-		},
-		"NeutralShadowAmbientLighter": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#0000001f"
-					}
-				}
-			}
-		},
-		"NeutralShadowKeyLighter": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000024"
-					}
-				}
-			}
-		},
-		"NeutralShadowAmbientDarker": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000066"
-					}
-				}
-			}
-		},
-		"NeutralShadowKeyDarker": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#0000007a"
-					}
-				}
-			}
-		},
-		"BrandShadowAmbient": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#0000004d"
-					}
-				}
-			}
-		},
-		"BrandShadowKey": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000040"
-					}
+	"NeutralForeground1": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"NeutralForeground2": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.84}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"BrandHover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.100}"
+				},
+				"BrandPressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.90}"
+				},
+				"BrandSelected": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.100}"
+				}
+			}
+		}
+	},
+	"NeutralForeground3": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.68}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.84}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.84}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.84}"
+				},
+				"BrandHover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.100}"
+				},
+				"BrandPressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.90}"
+				},
+				"BrandSelected": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.100}"
+				}
+			}
+		}
+	},
+	"NeutralForeground4": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.60}"
+				}
+			}
+		}
+	},
+	"NeutralForegroundDisabled": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.36}"
+				}
+			}
+		}
+	},
+	"NeutralForegroundInvertedDisabled": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.WhiteAlpha.40}"
+				}
+			}
+		}
+	},
+	"BrandForegroundLink": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.100}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.110}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.90}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.100}"
+				}
+			}
+		}
+	},
+	"NeutralForeground2Link": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.84}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"CompoundBrandForeground1": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.100}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.110}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.90}"
+				}
+			}
+		}
+	},
+	"BrandForeground1": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.100}"
+				}
+			}
+		}
+	},
+	"BrandForeground2": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.110}"
+				}
+			}
+		}
+	},
+	"NeutralForeground1Static": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				}
+			}
+		}
+	},
+	"NeutralForegroundStaticInverted": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"NeutralForegroundInverted": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				}
+			}
+		}
+	},
+	"NeutralForegroundInverted2": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				}
+			}
+		}
+	},
+	"NeutralForegroundOnBrand": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"NeutralForegroundInvertedLink": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"BrandForegroundInverted": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.70}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.60}"
+				}
+			}
+		}
+	},
+	"BrandForegroundOnLight": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.70}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.50}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.60}"
+				}
+			}
+		}
+	},
+	"NeutralBackground1": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.16}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.24}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.12}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.22}"
+				}
+			}
+		}
+	},
+	"NeutralBackground2": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.12}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.20}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.8}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.18}"
+				}
+			}
+		}
+	},
+	"NeutralBackground3": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.8}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.16}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.4}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				}
+			}
+		}
+	},
+	"NeutralBackground4": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.4}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.12}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Black}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.10}"
+				}
+			}
+		}
+	},
+	"NeutralBackground5": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Black}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.8}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.2}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.6}"
+				}
+			}
+		}
+	},
+	"NeutralBackground6": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.20}"
+				}
+			}
+		}
+	},
+	"NeutralBackgroundInverted": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"NeutralBackgroundStatic": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.24}"
+				}
+			}
+		}
+	},
+	"SubtleBackground": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000000"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.22}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.18}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.20}"
+				},
+				"LightAlphaHover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey14Alpha.80}"
+				},
+				"LightAlphaPressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey14Alpha.50}"
+				},
+				"LightAlphaSelected": {
+					"$type": "color",
+					"$value": "#00000000"
+				}
+			}
+		}
+	},
+	"SubtleBackgroundInverted": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000000"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.BlackAlpha.10}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.BlackAlpha.30}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.BlackAlpha.20}"
+				}
+			}
+		}
+	},
+	"TransparentBackground": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000000"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "#00000000"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "#00000000"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "#00000000"
+				}
+			}
+		}
+	},
+	"NeutralBackgroundDisabled": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.8}"
+				}
+			}
+		}
+	},
+	"NeutralBackgroundInvertedDisabled": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.WhiteAlpha.10}"
+				}
+			}
+		}
+	},
+	"NeutralStencil1": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.34}"
+				}
+			}
+		}
+	},
+	"NeutralStencil2": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.20}"
+				}
+			}
+		}
+	},
+	"NeutralStencil1Alpha": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.WhiteAlpha.10}"
+				}
+			}
+		}
+	},
+	"NeutralStencil2Alpha": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.WhiteAlpha.5}"
+				}
+			}
+		}
+	},
+	"BackgroundOverlay": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.BlackAlpha.50}"
+				}
+			}
+		}
+	},
+	"ScrollbarOverlay": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.WhiteAlpha.60}"
+				}
+			}
+		}
+	},
+	"BrandBackground": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.70}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.40}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.60}"
+				}
+			}
+		}
+	},
+	"CompoundBrandBackground": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.100}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.110}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.90}"
+				}
+			}
+		}
+	},
+	"BrandBackgroundStatic": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				}
+			}
+		}
+	},
+	"BrandBackground2": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.40}"
+				}
+			}
+		}
+	},
+	"BrandBackgroundInverted": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.160}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.140}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.150}"
+				}
+			}
+		}
+	},
+	"NeutralStrokeAccessible": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.68}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.74}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.70}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.100}"
+				}
+			}
+		}
+	},
+	"NeutralStroke1": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.40}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.46}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.42}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.44}"
+				}
+			}
+		}
+	},
+	"NeutralStroke2": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.32}"
+				}
+			}
+		}
+	},
+	"NeutralStroke3": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.24}"
+				}
+			}
+		}
+	},
+	"NeutralStrokeOnBrand": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.16}"
+				}
+			}
+		}
+	},
+	"NeutralStrokeOnBrand2": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"BrandStroke1": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.100}"
+				}
+			}
+		}
+	},
+	"BrandStroke2": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.50}"
+				}
+			}
+		}
+	},
+	"CompoundBrandStroke": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.100}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.110}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.90}"
+				}
+			}
+		}
+	},
+	"NeutralStrokeDisabled": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.26}"
+				}
+			}
+		}
+	},
+	"NeutralStrokeInvertedDisabled": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.WhiteAlpha.40}"
+				}
+			}
+		}
+	},
+	"TransparentStroke": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000000"
+				}
+			}
+		}
+	},
+	"TransparentStrokeInteractive": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000000"
+				}
+			}
+		}
+	},
+	"TransparentStrokeDisabled": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000000"
+				}
+			}
+		}
+	},
+	"StrokeFocus1": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Black}"
+				}
+			}
+		}
+	},
+	"StrokeFocus2": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"NeutralShadowAmbient": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#0000003d"
+				}
+			}
+		}
+	},
+	"NeutralShadowKey": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000047"
+				}
+			}
+		}
+	},
+	"NeutralShadowAmbientLighter": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#0000001f"
+				}
+			}
+		}
+	},
+	"NeutralShadowKeyLighter": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000024"
+				}
+			}
+		}
+	},
+	"NeutralShadowAmbientDarker": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000066"
+				}
+			}
+		}
+	},
+	"NeutralShadowKeyDarker": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#0000007a"
+				}
+			}
+		}
+	},
+	"BrandShadowAmbient": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#0000004d"
+				}
+			}
+		}
+	},
+	"BrandShadowKey": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000040"
 				}
 			}
 		}

--- a/src/demo/w3c/light.tokens.json
+++ b/src/demo/w3c/light.tokens.json
@@ -1,992 +1,990 @@
 {
-	"Neutral": {
-		"NeutralForeground1": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					}
-				}
-			}
-		},
-		"NeutralForeground2": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.26}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					},
-					"BrandHover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					},
-					"BrandPressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.70}"
-					},
-					"BrandSelected": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					}
-				}
-			}
-		},
-		"NeutralForeground3": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.38}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.26}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.26}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.26}"
-					},
-					"BrandHover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					},
-					"BrandPressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.70}"
-					},
-					"BrandSelected": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					}
-				}
-			}
-		},
-		"NeutralForeground4": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.44}"
-					}
-				}
-			}
-		},
-		"NeutralForegroundDisabled": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.74}"
-					}
-				}
-			}
-		},
-		"NeutralForegroundInvertedDisabled": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.WhiteAlpha.40}"
-					}
-				}
-			}
-		},
-		"BrandForegroundLink": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.70}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.60}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.40}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.70}"
-					}
-				}
-			}
-		},
-		"NeutralForeground2Link": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.26}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					}
-				}
-			}
-		},
-		"CompoundBrandForeground1": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.70}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.60}"
-					}
-				}
-			}
-		},
-		"BrandForeground1": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					}
-				}
-			}
-		},
-		"BrandForeground2": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.70}"
-					}
-				}
-			}
-		},
-		"NeutralForeground1Static": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.14}"
-					}
-				}
-			}
-		},
-		"NeutralForegroundStaticInverted": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"NeutralForegroundInverted": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"NeutralForegroundInverted2": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"NeutralForegroundOnBrand": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"NeutralForegroundInvertedLink": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"BrandForegroundInverted": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.100}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.110}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.100}"
-					}
-				}
-			}
-		},
-		"BrandForegroundOnLight": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.70}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.50}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.60}"
-					}
-				}
-			}
-		},
-		"NeutralBackground1": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.96}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.88}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.92}"
-					}
-				}
-			}
-		},
-		"NeutralBackground2": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.98}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.94}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.86}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.90}"
-					}
-				}
-			}
-		},
-		"NeutralBackground3": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.96}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.92}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.84}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.88}"
-					}
-				}
-			}
-		},
-		"NeutralBackground4": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.94}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.98}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.96}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"NeutralBackground5": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.92}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.96}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.94}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.98}"
-					}
-				}
-			}
-		},
-		"NeutralBackground6": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.90}"
-					}
-				}
-			}
-		},
-		"NeutralBackgroundInverted": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.16}"
-					}
-				}
-			}
-		},
-		"NeutralBackgroundStatic": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.20}"
-					}
-				}
-			}
-		},
-		"SubtleBackground": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000000"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.96}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.88}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.92}"
-					},
-					"LightAlphaHover": {
-						"$type": "color",
-						"$value": "{Global.Color.WhiteAlpha.70}"
-					},
-					"LightAlphaPressed": {
-						"$type": "color",
-						"$value": "{Global.Color.WhiteAlpha.50}"
-					},
-					"LightAlphaSelected": {
-						"$type": "color",
-						"$value": "#00000000"
-					}
-				}
-			}
-		},
-		"SubtleBackgroundInverted": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000000"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.BlackAlpha.10}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.BlackAlpha.30}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.BlackAlpha.20}"
-					}
-				}
-			}
-		},
-		"TransparentBackground": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000000"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "#00000000"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "#00000000"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "#00000000"
-					}
-				}
-			}
-		},
-		"NeutralBackgroundDisabled": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.94}"
-					}
-				}
-			}
-		},
-		"NeutralBackgroundInvertedDisabled": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.WhiteAlpha.10}"
-					}
-				}
-			}
-		},
-		"NeutralStencil1": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.90}"
-					}
-				}
-			}
-		},
-		"NeutralStencil2": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.98}"
-					}
-				}
-			}
-		},
-		"NeutralStencil1Alpha": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.BlackAlpha.10}"
-					}
-				}
-			}
-		},
-		"NeutralStencil2Alpha": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.BlackAlpha.5}"
-					}
-				}
-			}
-		},
-		"BackgroundOverlay": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.BlackAlpha.40}"
-					}
-				}
-			}
-		},
-		"ScrollbarOverlay": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.BlackAlpha.50}"
-					}
-				}
-			}
-		},
-		"BrandBackground": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.70}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.40}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.60}"
-					}
-				}
-			}
-		},
-		"CompoundBrandBackground": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.70}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.60}"
-					}
-				}
-			}
-		},
-		"BrandBackgroundStatic": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					}
-				}
-			}
-		},
-		"BrandBackground2": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.160}"
-					}
-				}
-			}
-		},
-		"BrandBackgroundInverted": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.160}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.140}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.150}"
-					}
-				}
-			}
-		},
-		"NeutralStrokeAccessible": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.38}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.34}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.30}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					}
-				}
-			}
-		},
-		"NeutralStroke1": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.82}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.78}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.70}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.74}"
-					}
-				}
-			}
-		},
-		"NeutralStroke2": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.88}"
-					}
-				}
-			}
-		},
-		"NeutralStroke3": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.94}"
-					}
-				}
-			}
-		},
-		"NeutralStrokeOnBrand": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"NeutralStrokeOnBrand2": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					},
-					"Selected": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"BrandStroke1": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					}
-				}
-			}
-		},
-		"BrandStroke2": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.140}"
-					}
-				}
-			}
-		},
-		"CompoundBrandStroke": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.80}"
-					},
-					"Hover": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.70}"
-					},
-					"Pressed": {
-						"$type": "color",
-						"$value": "{Global.Color.Brand.60}"
-					}
-				}
-			}
-		},
-		"NeutralStrokeDisabled": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Grey.88}"
-					}
-				}
-			}
-		},
-		"NeutralStrokeInvertedDisabled": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.WhiteAlpha.40}"
-					}
-				}
-			}
-		},
-		"TransparentStroke": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000000"
-					}
-				}
-			}
-		},
-		"TransparentStrokeInteractive": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000000"
-					}
-				}
-			}
-		},
-		"TransparentStrokeDisabled": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000000"
-					}
-				}
-			}
-		},
-		"StrokeFocus1": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.White}"
-					}
-				}
-			}
-		},
-		"StrokeFocus2": {
-			"Stroke": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "{Global.Color.Black}"
-					}
-				}
-			}
-		},
-		"NeutralShadowAmbient": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#0000001f"
-					}
-				}
-			}
-		},
-		"NeutralShadowKey": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000024"
-					}
-				}
-			}
-		},
-		"NeutralShadowAmbientLighter": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#0000000f"
-					}
-				}
-			}
-		},
-		"NeutralShadowKeyLighter": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000012"
-					}
-				}
-			}
-		},
-		"NeutralShadowAmbientDarker": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000033"
-					}
-				}
-			}
-		},
-		"NeutralShadowKeyDarker": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#0000003d"
-					}
-				}
-			}
-		},
-		"BrandShadowAmbient": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#0000004d"
-					}
-				}
-			}
-		},
-		"BrandShadowKey": {
-			"Fill": {
-				"Color": {
-					"Rest": {
-						"$type": "color",
-						"$value": "#00000040"
-					}
+	"NeutralForeground1": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				}
+			}
+		}
+	},
+	"NeutralForeground2": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.26}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				},
+				"BrandHover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				},
+				"BrandPressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.70}"
+				},
+				"BrandSelected": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				}
+			}
+		}
+	},
+	"NeutralForeground3": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.38}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.26}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.26}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.26}"
+				},
+				"BrandHover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				},
+				"BrandPressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.70}"
+				},
+				"BrandSelected": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				}
+			}
+		}
+	},
+	"NeutralForeground4": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.44}"
+				}
+			}
+		}
+	},
+	"NeutralForegroundDisabled": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.74}"
+				}
+			}
+		}
+	},
+	"NeutralForegroundInvertedDisabled": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.WhiteAlpha.40}"
+				}
+			}
+		}
+	},
+	"BrandForegroundLink": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.70}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.60}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.40}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.70}"
+				}
+			}
+		}
+	},
+	"NeutralForeground2Link": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.26}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				}
+			}
+		}
+	},
+	"CompoundBrandForeground1": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.70}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.60}"
+				}
+			}
+		}
+	},
+	"BrandForeground1": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				}
+			}
+		}
+	},
+	"BrandForeground2": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.70}"
+				}
+			}
+		}
+	},
+	"NeutralForeground1Static": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.14}"
+				}
+			}
+		}
+	},
+	"NeutralForegroundStaticInverted": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"NeutralForegroundInverted": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"NeutralForegroundInverted2": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"NeutralForegroundOnBrand": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"NeutralForegroundInvertedLink": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"BrandForegroundInverted": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.100}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.110}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.100}"
+				}
+			}
+		}
+	},
+	"BrandForegroundOnLight": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.70}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.50}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.60}"
+				}
+			}
+		}
+	},
+	"NeutralBackground1": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.96}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.88}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.92}"
+				}
+			}
+		}
+	},
+	"NeutralBackground2": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.98}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.94}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.86}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.90}"
+				}
+			}
+		}
+	},
+	"NeutralBackground3": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.96}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.92}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.84}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.88}"
+				}
+			}
+		}
+	},
+	"NeutralBackground4": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.94}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.98}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.96}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"NeutralBackground5": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.92}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.96}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.94}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.98}"
+				}
+			}
+		}
+	},
+	"NeutralBackground6": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.90}"
+				}
+			}
+		}
+	},
+	"NeutralBackgroundInverted": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.16}"
+				}
+			}
+		}
+	},
+	"NeutralBackgroundStatic": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.20}"
+				}
+			}
+		}
+	},
+	"SubtleBackground": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000000"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.96}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.88}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.92}"
+				},
+				"LightAlphaHover": {
+					"$type": "color",
+					"$value": "{Global.Color.WhiteAlpha.70}"
+				},
+				"LightAlphaPressed": {
+					"$type": "color",
+					"$value": "{Global.Color.WhiteAlpha.50}"
+				},
+				"LightAlphaSelected": {
+					"$type": "color",
+					"$value": "#00000000"
+				}
+			}
+		}
+	},
+	"SubtleBackgroundInverted": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000000"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.BlackAlpha.10}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.BlackAlpha.30}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.BlackAlpha.20}"
+				}
+			}
+		}
+	},
+	"TransparentBackground": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000000"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "#00000000"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "#00000000"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "#00000000"
+				}
+			}
+		}
+	},
+	"NeutralBackgroundDisabled": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.94}"
+				}
+			}
+		}
+	},
+	"NeutralBackgroundInvertedDisabled": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.WhiteAlpha.10}"
+				}
+			}
+		}
+	},
+	"NeutralStencil1": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.90}"
+				}
+			}
+		}
+	},
+	"NeutralStencil2": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.98}"
+				}
+			}
+		}
+	},
+	"NeutralStencil1Alpha": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.BlackAlpha.10}"
+				}
+			}
+		}
+	},
+	"NeutralStencil2Alpha": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.BlackAlpha.5}"
+				}
+			}
+		}
+	},
+	"BackgroundOverlay": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.BlackAlpha.40}"
+				}
+			}
+		}
+	},
+	"ScrollbarOverlay": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.BlackAlpha.50}"
+				}
+			}
+		}
+	},
+	"BrandBackground": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.70}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.40}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.60}"
+				}
+			}
+		}
+	},
+	"CompoundBrandBackground": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.70}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.60}"
+				}
+			}
+		}
+	},
+	"BrandBackgroundStatic": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				}
+			}
+		}
+	},
+	"BrandBackground2": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.160}"
+				}
+			}
+		}
+	},
+	"BrandBackgroundInverted": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.160}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.140}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.150}"
+				}
+			}
+		}
+	},
+	"NeutralStrokeAccessible": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.38}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.34}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.30}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				}
+			}
+		}
+	},
+	"NeutralStroke1": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.82}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.78}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.70}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.74}"
+				}
+			}
+		}
+	},
+	"NeutralStroke2": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.88}"
+				}
+			}
+		}
+	},
+	"NeutralStroke3": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.94}"
+				}
+			}
+		}
+	},
+	"NeutralStrokeOnBrand": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"NeutralStrokeOnBrand2": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				},
+				"Selected": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"BrandStroke1": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				}
+			}
+		}
+	},
+	"BrandStroke2": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.140}"
+				}
+			}
+		}
+	},
+	"CompoundBrandStroke": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.80}"
+				},
+				"Hover": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.70}"
+				},
+				"Pressed": {
+					"$type": "color",
+					"$value": "{Global.Color.Brand.60}"
+				}
+			}
+		}
+	},
+	"NeutralStrokeDisabled": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Grey.88}"
+				}
+			}
+		}
+	},
+	"NeutralStrokeInvertedDisabled": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.WhiteAlpha.40}"
+				}
+			}
+		}
+	},
+	"TransparentStroke": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000000"
+				}
+			}
+		}
+	},
+	"TransparentStrokeInteractive": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000000"
+				}
+			}
+		}
+	},
+	"TransparentStrokeDisabled": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000000"
+				}
+			}
+		}
+	},
+	"StrokeFocus1": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.White}"
+				}
+			}
+		}
+	},
+	"StrokeFocus2": {
+		"Stroke": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "{Global.Color.Black}"
+				}
+			}
+		}
+	},
+	"NeutralShadowAmbient": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#0000001f"
+				}
+			}
+		}
+	},
+	"NeutralShadowKey": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000024"
+				}
+			}
+		}
+	},
+	"NeutralShadowAmbientLighter": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#0000000f"
+				}
+			}
+		}
+	},
+	"NeutralShadowKeyLighter": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000012"
+				}
+			}
+		}
+	},
+	"NeutralShadowAmbientDarker": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000033"
+				}
+			}
+		}
+	},
+	"NeutralShadowKeyDarker": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#0000003d"
+				}
+			}
+		}
+	},
+	"BrandShadowAmbient": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#0000004d"
+				}
+			}
+		}
+	},
+	"BrandShadowKey": {
+		"Fill": {
+			"Color": {
+				"Rest": {
+					"$type": "color",
+					"$value": "#00000040"
 				}
 			}
 		}

--- a/src/pipeline/figmatokens.ts
+++ b/src/pipeline/figmatokens.ts
@@ -111,7 +111,7 @@ export const getFigmaTokensJson = (props: any[], options: unknown = {}): any =>
 
 		// First, find or recreate this token's parent group in the new tokens object.
 		let group: any = tokens.Fluent
-		const path = thisProp.path[0] === "Set" ? thisProp.path.slice(1, -1) : thisProp.path.slice(0, -1)
+		const path = thisProp.path.slice(0, -1)
 		for (const segment of path)
 		{
 			if (segment in group)

--- a/src/pipeline/fluentui-css.ts
+++ b/src/pipeline/fluentui-css.ts
@@ -220,12 +220,12 @@ StyleDictionary.registerTransform({
 
 StyleDictionary.registerTransformGroup({
 	name: "fluentui/css",
-	transforms: ["fluentui/name/kebab", "fluentui/alias/css", "time/seconds", "fluentui/size/css", "fluentui/color/css", "fluentui/strokealignment/css", "fluentui/letterspacing/css", "fluentui/shadow/css"],
+	transforms: ["fluentui/name/kebab", "time/seconds", "fluentui/size/css", "fluentui/color/css", "fluentui/strokealignment/css", "fluentui/letterspacing/css", "fluentui/shadow/css", "fluentui/alias/css"],
 })
 
 StyleDictionary.registerTransformGroup({
 	name: "fluentui/scss",
-	transforms: ["fluentui/name/kebab", "fluentui/alias/scss", "time/seconds", "fluentui/size/css", "fluentui/color/css", "fluentui/strokealignment/css", "fluentui/letterspacing/css", "fluentui/shadow/css"],
+	transforms: ["fluentui/name/kebab", "time/seconds", "fluentui/size/css", "fluentui/color/css", "fluentui/strokealignment/css", "fluentui/letterspacing/css", "fluentui/shadow/css", "fluentui/alias/scss"],
 })
 
 StyleDictionary.registerTransformGroup({

--- a/src/pipeline/fluentui-dcs.ts
+++ b/src/pipeline/fluentui-dcs.ts
@@ -9,15 +9,7 @@ const constructCssName = (path: any[]): string =>
 {
 	let newName = path[0] !== "Global" && path[3] === "Color" ? `color${path.join("")}` : path.join("")
 	newName = newName.charAt(0).toLowerCase() + newName.slice(1)
-	newName = newName.replace("NeutralNeutral", "Neutral")
-	newName = newName.replace("NeutralBrand", "Brand")
-	newName = newName.replace("NeutralCompound", "Compound")
-	newName = newName.replace("NeutralRed", "PaletteRed")
-	newName = newName.replace("NeutralGreen", "PaletteGreen")
-	newName = newName.replace("NeutralDarkOrange", "PaletteDarkOrange")
-	newName = newName.replace("NeutralYellow", "PaletteYellow")
 	newName = newName.replace("Rest", "")
-	newName = newName.replace("set", "")
 	newName = newName.replace("FillColor", "")
 	newName = newName.replace("StrokeColor", "")
 	newName = newName.replace("BorderColor", "")
@@ -53,12 +45,12 @@ StyleDictionary.registerTransform({
 
 StyleDictionary.registerTransformGroup({
 	name: "dcs/json",
-	transforms: ["dcs/name/json", "dcs/alias/json", "time/seconds", "fluentui/size/css", "fluentui/color/css", "fluentui/strokealignment/css", "fluentui/shadow/css"],
+	transforms: ["dcs/name/json", "time/seconds", "fluentui/size/css", "fluentui/color/css", "fluentui/strokealignment/css", "fluentui/shadow/css", "dcs/alias/json"],
 })
 
 StyleDictionary.registerTransformGroup({
 	name: "dcs/css",
-	transforms: ["dcs/name/css", "dcs/alias/css", "time/seconds", "fluentui/size/css", "fluentui/color/css", "fluentui/strokealignment/css", "fluentui/shadow/css"],
+	transforms: ["dcs/name/css", "time/seconds", "fluentui/size/css", "fluentui/color/css", "fluentui/strokealignment/css", "fluentui/shadow/css", "dcs/alias/css"],
 })
 
 StyleDictionary.registerFormat({
@@ -98,15 +90,7 @@ StyleDictionary.registerFormat({
 				? `color${_.camelCase(thisProp.path.slice(0).join(""))}`
 				: _.camelCase(thisProp.path.slice(0).join(""))
 
-			exportName = exportName.replace("NeutralNeutral", "Neutral")
-			exportName = exportName.replace("NeutralBrand", "Brand")
-			exportName = exportName.replace("NeutralCompound", "Compound")
-			exportName = exportName.replace("NeutralRed", "PaletteRed")
-			exportName = exportName.replace("NeutralGreen", "PaletteGreen")
-			exportName = exportName.replace("NeutralDarkOrange", "PaletteDarkOrange")
-			exportName = exportName.replace("NeutralYellow", "PaletteYellow")
 			exportName = exportName.replace("Rest", "")
-			exportName = exportName.replace("set", "")
 			exportName = exportName.replace("FillColor", "")
 			exportName = exportName.replace("StrokeColor", "")
 			exportName = exportName.replace("BorderColor", "")

--- a/src/pipeline/fluentui-html.ts
+++ b/src/pipeline/fluentui-html.ts
@@ -75,20 +75,12 @@ StyleDictionary.registerFormat({
 			{
 				header = "<h1>Global tokens</h1>\n\n"
 			}
-			else if (thisProp.path[0] === "Set" && (!previousProp || previousProp.path[0] !== "Set"))
+			else if (thisProp.path[0] !== "Global" && (!previousProp || previousProp.path[0] === "Global"))
 			{
 				header = "<h1>Alias tokens</h1>\n\n"
 			}
-			else if (thisProp.path[0] !== "Global" && thisProp.path[0] !== "Set" && (!previousProp || previousProp.path[0] === "Global" || previousProp.path[0] === "Set"))
-			{
-				header = "<h1>Control tokens</h1>\n\n"
-			}
 
-			if (thisProp.path[0] === "Set" && (!previousProp || thisProp.path[1] !== previousProp.path[1]))
-			{
-				header = (header || "") + `<h2>Set-${thisProp.path[1]}</h2>\n\n`
-			}
-			else if (thisProp.path[0] !== "Global" && thisProp.path[0] !== "Set" && (!previousProp || thisProp.path[0] !== previousProp.path[0]))
+			if (thisProp.path[0] !== "Global" && (!previousProp || thisProp.path[0] !== previousProp.path[0]))
 			{
 				header = (header || "") + `<h2>${thisProp.path[0]}</h2>\n\n`
 			}
@@ -98,13 +90,6 @@ StyleDictionary.registerFormat({
 				if (previousProp) list += "</div>\n\n"
 				list += header
 				list += "<div class=\"tokentable\">\n\n"
-			}
-
-			if (thisProp.path[0] !== "Global" && thisProp.path[0] !== "Set" && (!previousProp || thisProp.path[1] !== previousProp.path[1]))
-			{
-				// The H3-level headers inside of the control token tables (such as "Base" for "Button-Base-Fill-Color-Rest")
-				// go INSIDE the table.
-				list += `<h3>${thisProp.path[1]}</h3>\n\n`
 			}
 
 			previousProp = thisProp

--- a/src/pipeline/fluentui-json.ts
+++ b/src/pipeline/fluentui-json.ts
@@ -50,7 +50,7 @@ StyleDictionary.registerFormat({
 				rootName = _.camelCase(thisProp.path[1])
 				subgroupName = _.camelCase(thisProp.path[2])
 			}
-			else if ((rootName === "set" || rootName === "global") && thisProp.path.length > 2)
+			else if (rootName === "global" && thisProp.path.length > 2)
 			{
 				meaningfulPathStart = 2
 				rootName = _.camelCase(thisProp.path[1])

--- a/src/pipeline/fluentui-shared.ts
+++ b/src/pipeline/fluentui-shared.ts
@@ -43,6 +43,9 @@ export const setAttributesFromNames = (tokens: TokenSet): TokenSet =>
 	// IMPORTANT! This is designed to be used AFTER resolveAliases and its kin. It will miss things like aliases if any remain.
 	Utils.forEachRecursive(tokens, (prop: any, path: ReadonlyArray<string>) =>
 	{
+		// If the token already has a category set (normal for W3C files), skip it.
+		if (prop.attributes && prop.attributes.category) return
+
 		/*
 			Transforms all properties to add appropriate category and xamlType fields.
 			(Fluent UI token names use a different structure than the Category-Type-Item structure recommended
@@ -61,9 +64,9 @@ export const setAttributesFromNames = (tokens: TokenSet): TokenSet =>
 		}
 		else
 		{
-			sdAttributes = path[path.length - 2] === "Color"
-				? getSDAttributes(path[path.length - 3], path[path.length - 2])
-				: getSDAttributes(path[2], path[3])
+			sdAttributes = path[path.length - 1] === "Color"
+				? getSDAttributes(path[path.length - 2], path[path.length - 1])
+				: getSDAttributes(path[1], path[2])
 		}
 
 		if (!sdAttributes)
@@ -91,21 +94,12 @@ StyleDictionary.registerTransform({
 
 StyleDictionary.registerFilter({
 	name: "isAlias",
-	matcher: prop => prop.path[0] === "Set",
+	matcher: prop => prop.path[0] !== "Global",
 })
 
 StyleDictionary.registerFilter({
 	name: "isGlobal",
 	matcher: prop => prop.path[0] === "Global",
-})
-
-StyleDictionary.registerFilter({
-	name: "isControl",
-	matcher: prop =>
-	{
-		const rootName = prop.path[0]
-		return rootName !== "Global" && rootName !== "Set"
-	},
 })
 
 StyleDictionary.registerFilter({

--- a/src/pipeline/fluentui-w3c.ts
+++ b/src/pipeline/fluentui-w3c.ts
@@ -67,7 +67,6 @@ StyleDictionary.registerTransform({
 		return prop.value.map(shadow =>
 		{
 			// It isn't currently possible to have Style Dictionary export strings with {}, so use [] instead.
-			// REVIEW: Do we need to strip "Set." here?
 			const color = shadow.color.resolvedAliasPath ? `[${shadow.color.resolvedAliasPath.join(".")}]` : colorTokenToHexColorFallback(shadow.color.value)
 			return {
 				color: color,
@@ -107,7 +106,7 @@ export const getW3CJson = (props: any[], options: unknown = {}): any =>
 
 		// First, find or recreate this token's parent group in the new tokens object.
 		let group: any = tokens
-		for (const segment of thisProp.path.slice(thisProp.path[0] === "Set" ? 1 : 0, -1))
+		for (const segment of thisProp.path.slice(0, -1))
 		{
 			if (segment in group)
 				group = group[segment]
@@ -128,7 +127,6 @@ export const getValueOrReference = (prop: any): any =>
 {
 	if (prop.resolvedAliasPath)
 	{
-		// REVIEW: Do we need to strip "Set" here?
 		return `{${prop.resolvedAliasPath.join(".")}}`
 	}
 	else

--- a/src/pipeline/index.ts
+++ b/src/pipeline/index.ts
@@ -40,7 +40,6 @@ export const buildOutputs = (input: string[] | string, outputPath: string, platf
 				}
 			}
 		}
-		
 	}
 
 
@@ -72,7 +71,6 @@ export const buildOutputs = (input: string[] | string, outputPath: string, platf
 				files: [
 					{ destination: "tokens-global.json", format: "fluentui/json/grouped", filter: "isGlobal" },
 					{ destination: "tokens-aliases.json", format: "fluentui/json/grouped", filter: "isAlias" },
-					{ destination: "tokens-controls.json", format: "fluentui/json/grouped", filter: "isControl" },
 				],
 			}
 		}
@@ -172,7 +170,6 @@ export const buildOutputs = (input: string[] | string, outputPath: string, platf
 					{ destination: "tokens-global.json", format: "fluentui/json/grouped", filter: "isGlobalNotShadow" },
 					{ destination: "tokens-shadow.json", format: "fluentui/json/grouped", filter: "isGlobalShadow" },
 					{ destination: "tokens-aliases.json", format: "fluentui/json/grouped", filter: "isAlias" },
-					{ destination: "tokens-controls.json", format: "fluentui/json/grouped", filter: "isControl" },
 				],
 			}
 		},

--- a/src/pipeline/load.ts
+++ b/src/pipeline/load.ts
@@ -37,17 +37,7 @@ const convertW3CTokens = (tokens: any): TokenJson =>
 		if (isReservedW3CName(childName)) continue
 		if (!tokens.hasOwnProperty(childName)) continue
 
-		if (childName === "Global")
-		{
-			convertAndCopyTokens(tokens.Global, converted.Global = {})
-		}
-		else
-		{
-			// Anything that's not in the Global namespace gets "Set." prepended to the name so that existing code that assumes
-			// that word will be there will continue working.
-			if (!("Set" in converted)) converted.Set = {}
-			convertAndCopyTokens(tokens[childName], converted.Set[childName] = {})
-		}
+		convertAndCopyTokens(tokens[childName], converted[childName] = {})
 	}
 	return converted as TokenJson
 }
@@ -154,5 +144,4 @@ const getW3CAliasTargetName = (value: any): string | null =>
 	if (typeof value === "string" && value.charCodeAt(0) === 123 /* "{" */ && value.charCodeAt(value.length - 1) === 125 /* "}" */)
 		return value.slice(1, -1)
 	else return null
-	// REVIEW: Do we need to re-add "Set." here?
 }

--- a/src/pipeline/load.ts
+++ b/src/pipeline/load.ts
@@ -68,7 +68,7 @@ const convertAndCopyTokens = (from: any, to: TokenSet): void =>
 const getConvertedToken = (w3cToken: Record<string, any>): Token =>
 {
 	let value = w3cToken.$value
-	let attributes: any = { w3cType: w3cToken.$type }
+	let attributes: any = {}
 	const aliasTarget = getW3CAliasTargetName(value)
 	const converted: any = aliasTarget ? { aliasOf: aliasTarget } : {}
 
@@ -120,6 +120,7 @@ const getConvertedToken = (w3cToken: Record<string, any>): Token =>
 	}
 
 	if (!aliasTarget) converted.value = value
+	attributes.w3cType = w3cToken.$type
 	converted.attributes = attributes
 	return converted as unknown as Token
 }

--- a/src/pipeline/utils.ts
+++ b/src/pipeline/utils.ts
@@ -39,9 +39,6 @@ export const getTokenExportPath = (prop: Token, propPath?: string): string[] =>
 	if (!path)
 		throw new Error(`Path wasn't present in token OR specified for getTokenExportPath: ${JSON.stringify(prop)}`)
 
-	// Strip off "Set" if present.
-	if (path.length > 1 && path[0] === "Set") path = path.slice(1)
-
 	return path
 }
 
@@ -58,10 +55,6 @@ export const sortPropertiesForReadability = (dictionary: any[]): any[] =>
 		// Global tokens before everything else.
 		if (categoryA === "Global" && categoryB !== "Global") return -1
 		else if (categoryB === "Global" && categoryA !== "Global") return 1
-
-		// Alias sets before everything else except Global tokens.
-		if (categoryA === "Set" && categoryB !== "Set") return -1
-		else if (categoryB === "Set" && categoryA !== "Set") return 1
 
 		// Check each path segment except the last one in order.
 		const minLength = Math.min(a.path.length, b.path.length)
@@ -181,6 +174,14 @@ export const mergeNumbers = (subtree: TokenSet, setName?: string): TokenSet =>
 		if (!searching.hasOwnProperty(key)) continue
 		const prop: TokenSet | Token = searching[key]
 		if (typeof prop !== "object") continue
+
+		// Special case for when legacy brand colors and modern brand colors are both present:
+		// if there's a child named "Primary", skip this one entirely.
+		if (key === "Primary")
+		{
+			shouldMerge = false
+			break
+		}
 
 		// Okay, we'll merge this and all other children.
 		shouldMerge = shouldMerge || canMerge && /^[0-9]+$/.test(key)


### PR DESCRIPTION
Various places in the token pipeline assume that the token files have all of our alias tokens in a node called `Set`, but we haven't used the word "Set" in our alias token names for years. This change removes that requirement.

In addition, the React outputs only work when the alias tokens are in a node called `Neutral`, which is really confusing because there are also non-neutral tokens like `BrandForeground1` in there. This change removes that requirement as well.